### PR TITLE
Edit camera default pixelsize and rotation value

### DIFF
--- a/macroscope.ini
+++ b/macroscope.ini
@@ -17,8 +17,8 @@ move_image_space_mode = 0
 default_settings = /home/monika/Documents/wormies/settings_wormies_2022-08-08.pfs
 zoom = 3
 display_fps = 15
-pixelsize = inf
-rotation = -0.7853981633974483
+pixelsize = 1
+rotation = 0
 
 [Autofocus]
 step_size = 0.5


### PR DESCRIPTION
Fix default infinite pixelsize value causes tracking error.