### PR TITLE
Fix running local environment error

### DIFF
--- a/glowtracker/GlowTracker.py
+++ b/glowtracker/GlowTracker.py
@@ -57,6 +57,7 @@ from queue import Queue
 from overrides import override
 from typing import Tuple
 from io import TextIOWrapper
+import zaber_motion     # We need to import zaber_motion before pypylon to prevent environment crash
 from pypylon import pylon
 
 # 


### PR DESCRIPTION
Fix an error that has been happening since the restructure of the project, where we can not run the software locally through the source code but can run as an installed pip package.

When trying to run the repo on some machine, it would gives an error saying it could not find the `zaber_motion` module at the following line: https://github.com/scholz-lab/GlowTracker/blob/9ab2032db12f0f2bd98b6cbaa1fd8b8a60566e50/glowtracker/Zaber_control.py#L2 
even the environment does have the package and could be imported fine through the python terminal
```bash
$ python
>>>import zaber_motion
>>>print('zaber_motion')
<module 'zaber_motion' from ... >
```

After trial-and-error, I found that if we import the module before importing `pypylon` package, 
https://github.com/scholz-lab/GlowTracker/blob/9ab2032db12f0f2bd98b6cbaa1fd8b8a60566e50/glowtracker/GlowTracker.py#L60
every thing would work fine and we could run the software locally through the source code. But importing `zaber_motion` after `pypylon` would result in the said error.

**Not error:** :white_check_mark:
 ```python
  import zaber_motion
  from pypylon import pylon
 ```

**Error:** :x:
 ```python
 from pypylon import pylon
 import zaber_motion
 ```

Since this issue only happens in some machine. My best guess is that it is caused by memory layout conflicts when loading the modules. But I wouldn't be able to prove it for now and solve it as it is. Please test on your machine as well.