### PR TITLE
Update the project to support Python 3.10, 3.11, 3.12, 3.13

### DIFF
--- a/.github/workflows/install_package.yml
+++ b/.github/workflows/install_package.yml
@@ -32,8 +32,8 @@ jobs:
           echo "runner os: ${{ runner.os }}"
           echo "matrix os: ${{ matrix.os }}"
       - name: Update pip
-        run: 
-          python -m pip install --upgrade pip 
+        run: |
+          python -m pip install --upgrade pip
           python -m pip install --upgrade setuptools wheel pip-tools
       - name: Compile requirements
         # Generate the requirements.txt file listed in pyproject.toml

--- a/.github/workflows/install_package.yml
+++ b/.github/workflows/install_package.yml
@@ -33,15 +33,15 @@ jobs:
           echo "matrix os: ${{ matrix.os }}"
       - name: Update pip
         run: |
-          python -m pip install --upgrade "pip<25"
+          # The newest pip version (25.3) force support of PEP 517 and will cause error in pip-tools.
+          # Have to wait for a newer than version 7.5.1 piptools 
+          python -m pip install --upgrade "pip<25.3"
           python -m pip install --upgrade setuptools wheel pip-tools
       - name: Compile requirements
         # Generate the requirements.txt file listed in pyproject.toml
         # NOTE: This step overwrites any previously existing requirements.txt file
-        run: |
-          pip-compile ${{ github.workspace }}/pyproject.toml --output-file=requirements.txt --upgrade
-          # python -m piptools compile -o requirements.txt ${{ github.workspace }}/pyproject.toml --upgrade
-          # python -m piptools compile pyproject.toml -o requirements.txt --upgrade
+        run:
+          python -m piptools compile -o requirements.txt ${{ github.workspace }}/pyproject.toml --upgrade
       - name: Install dependencies Linux/macOS
         if: runner.os == 'Linux' || runner.os == 'macOS'
         run:

--- a/.github/workflows/install_package.yml
+++ b/.github/workflows/install_package.yml
@@ -33,7 +33,7 @@ jobs:
           echo "matrix os: ${{ matrix.os }}"
       - name: Update pip
         run: 
-          python -m pip install --upgrade pip setuptools pip-tools
+          python -m pip install --upgrade pip setuptools wheel pip-tools
       - name: Compile requirements
         # Generate the requirements.txt file listed in pyproject.toml
         # NOTE: This step overwrites any previously existing requirements.txt file

--- a/.github/workflows/install_package.yml
+++ b/.github/workflows/install_package.yml
@@ -31,6 +31,9 @@ jobs:
         run: |
           echo "runner os: ${{ runner.os }}"
           echo "matrix os: ${{ matrix.os }}"
+      - name: Update pip
+        run: 
+          python -m pip install --upgrade pip
       - name: Compile requirements
         # Generate the requirements.txt file listed in pyproject.toml
         # NOTE: This step overwrites any previously existing requirements.txt file

--- a/.github/workflows/install_package.yml
+++ b/.github/workflows/install_package.yml
@@ -33,12 +33,11 @@ jobs:
           echo "matrix os: ${{ matrix.os }}"
       - name: Update pip
         run: 
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade pip setuptools pip-tools
       - name: Compile requirements
         # Generate the requirements.txt file listed in pyproject.toml
         # NOTE: This step overwrites any previously existing requirements.txt file
         run: |
-          python -m pip install pip-tools
           python -m piptools compile -o requirements.txt ${{ github.workspace }}/pyproject.toml --upgrade
       - name: Install dependencies Linux/macOS
         if: runner.os == 'Linux' || runner.os == 'macOS'

--- a/.github/workflows/install_package.yml
+++ b/.github/workflows/install_package.yml
@@ -33,7 +33,8 @@ jobs:
           echo "matrix os: ${{ matrix.os }}"
       - name: Update pip
         run: 
-          python -m pip install --upgrade pip setuptools wheel pip-tools
+          python -m pip install --upgrade pip 
+          python -m pip install --upgrade setuptools wheel pip-tools
       - name: Compile requirements
         # Generate the requirements.txt file listed in pyproject.toml
         # NOTE: This step overwrites any previously existing requirements.txt file

--- a/.github/workflows/install_package.yml
+++ b/.github/workflows/install_package.yml
@@ -18,14 +18,13 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        #python-version: ["3.8", "3.9"] # didn't pass the testing
-        python-version: ["3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - name: Checkout glowtracker
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Debug action..

--- a/.github/workflows/install_package.yml
+++ b/.github/workflows/install_package.yml
@@ -33,7 +33,7 @@ jobs:
           echo "matrix os: ${{ matrix.os }}"
       - name: Update pip
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade "pip<25"
           python -m pip install --upgrade setuptools wheel pip-tools
       - name: Compile requirements
         # Generate the requirements.txt file listed in pyproject.toml

--- a/.github/workflows/install_package.yml
+++ b/.github/workflows/install_package.yml
@@ -38,7 +38,9 @@ jobs:
         # Generate the requirements.txt file listed in pyproject.toml
         # NOTE: This step overwrites any previously existing requirements.txt file
         run: |
-          python -m piptools compile -o requirements.txt ${{ github.workspace }}/pyproject.toml --upgrade
+          pip-compile ${{ github.workspace }}/pyproject.toml --output-file=requirements.txt --upgrade
+          # python -m piptools compile -o requirements.txt ${{ github.workspace }}/pyproject.toml --upgrade
+          # python -m piptools compile pyproject.toml -o requirements.txt --upgrade
       - name: Install dependencies Linux/macOS
         if: runner.os == 'Linux' || runner.os == 'macOS'
         run:

--- a/.github/workflows/publish_package.yml
+++ b/.github/workflows/publish_package.yml
@@ -27,10 +27,10 @@ jobs:
     steps:
       # Checkout the repository
       - name: Checkout glowtracker
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       # Set up Python environment
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: '3.10'
       # Updating pip and installing 'build'.

--- a/BUILD.md
+++ b/BUILD.md
@@ -5,23 +5,18 @@ Then Execute the build process by
 ```bash
 python -m build
 ```
+or
+```bash
+uv build
+```
 The resulting packages will be in `dist/`, `glowtracker-[version].tar.gz` and `glowtracker-[version]-py3-none-any.why`.
 **Don't forget** to change the version accordingly. Following the convention of Major.Minor.Patch.
 
 # Testing installing the package
-- We can test the package by install directly and locally form
-    ```bash
-    python -m pip install dist/glowtracker-[version].tar.gz
-    ```
-
-- Or by uploading to the TestPyPI first
-    ```bash
-    twine upload --repository testpypi dist/*
-    ```
-    and then install the online version via pip
-    ```bash
-    pip install -i https://test.pypi.org/simple/ glowtracker==[version]
-    ```
+We can test the package by install directly and locally form
+```bash
+python -m pip install dist/glowtracker-[version].tar.gz
+```
 
 # Running
 Once the package is installed, the application can be started by

--- a/README.md
+++ b/README.md
@@ -18,32 +18,30 @@
 
 ## Getting started
 ### Software Setup
-1. Create and activate a python environment using **venv** or **Conda**.
+1. Create a Python environment using **uv** (recommend) or **venv**.
+    - Using **uv** (Recommend)
+        1. Install uv [[Link]](https://docs.astral.sh/uv/getting-started/installation/).
+        2. Create a virtual environment
+            ```bash
+            uv venv glowtracker.venv
+            ```
     - Using **venv**
-
-        GlowTracker requires python version of at least 3.10. If you do not have one, please download from [[Python]](https://www.python.org/downloads/).
         1. Create the environment
             ```bash
-            python -m venv glowtracker
+            python -m venv glowtracker.venv
             ```
-        2. Activate the environment
-            ```bash
-            source glowtracker/Scripts/activate
-            ```
-    - Using **Conda**
-        1. Install **Conda** [[Link]](https://conda.io/projects/conda/en/latest/user-guide/install/index.html)
-        2. Use `conda` to create a new python environment named `glowtracker`.
-            ```bash
-            conda create -n glowtracker "python>=3.10,<3.12"
-            ```
-        3. Activate the `glowtracker` environment 
-            ```bash
-            conda activate glowtracker
-            ```
-2. Install the `glowtracker` package.
+
+2. Activate the environment
+    ```bash
+    source glowtracker.venv/Scripts/activate
+    ```
+
+3. Install GlowTracker
+    You can choose to either install GlowTracker from a distributed Python package from PyPI or clone the git repository and run them locally.
+
     - Using `pip` to install from PyPI repository:
         ```bash
-        python -m pip install glowtracker
+        uv pip install glowtracker
         ```
     - Or clone and run the package locally.
         1. Clone the pository
@@ -53,17 +51,17 @@
         2. Update the conda environment to download the dependencies
             ```bash
             cd Glowtracker;
-            conda env update --file glowtracker/StageEnvironment.yml --prune
+            uv pip install -r pyproject.toml;
             ```
 
 
-3. Install the **BASLER** pylon software and runtime library [[Link]](https://www.baslerweb.com/en/software/pylon/)
+4. Install the **BASLER** pylon software and runtime library [[Link]](https://www.baslerweb.com/en/software/pylon/)
     - pylon Camera Software Suite
     - pylon runtime library
 
-4. (Optional) Install **Zaber Launcher** for inspecting and updating stage firmware [[Link]](https://software.zaber.com/zaber-launcher/download)
+5. (Optional) Install **Zaber Launcher** for inspecting and updating stage firmware [[Link]](https://software.zaber.com/zaber-launcher/download)
 
-5. After finished installation, the software can be started in several ways
+6. After finished installation, the software can be started in several ways
     - If you have installed it via pip
         ```bash
         python -m glowtracker

--- a/glowtracker/Basler_control.py
+++ b/glowtracker/Basler_control.py
@@ -175,7 +175,7 @@ class Camera(pylon.InstantCamera):
             # cam stop
             self.AcquisitionStop.Execute()
             # grab unlock
-            self.TLParamsLocked = False
+            self.TLParamsLocked.Value = False
 
             prevCameraWidth = self.Width()
             prevCameraHeight = self.Height()
@@ -201,11 +201,11 @@ class Camera(pylon.InstantCamera):
                 offsetY = max(offsetY, 4)
 
                 # Set the camera offset
-                self.OffsetX = offsetX
-                self.OffsetY = offsetY
+                self.OffsetX.Value = offsetX
+                self.OffsetY.Value = offsetY
                 
             # grab lock
-            self.TLParamsLocked = True
+            self.TLParamsLocked.Value = True
             # cam start
             self.AcquisitionStart.Execute()
             # Set camera on hold flag
@@ -224,15 +224,15 @@ class Camera(pylon.InstantCamera):
         # cam stop
         self.AcquisitionStop.Execute()
         # grab unlock
-        self.TLParamsLocked = False
+        self.TLParamsLocked.Value = False
 
-        self.OffsetX = 0
+        self.OffsetX.Value = 0
         self.OffsetY = 0
         self.Width = self.Width.Max
         self.Height = self.Height.Max
 
         # grab lock
-        self.TLParamsLocked = True
+        self.TLParamsLocked.Value = True
         # cam start
         self.AcquisitionStart.Execute()
 
@@ -249,8 +249,8 @@ class Camera(pylon.InstantCamera):
             fps (float): the resulting framerate
         """
         
-        self.AcquisitionFrameRateEnable = True
-        self.AcquisitionFrameRate = float(fps)
+        self.AcquisitionFrameRateEnable.Value = True
+        self.AcquisitionFrameRate.Value = float(fps)
         return self.ResultingFrameRate()
     
 

--- a/glowtracker/GlowTracker.py
+++ b/glowtracker/GlowTracker.py
@@ -1980,7 +1980,7 @@ class PreviewImage(Image):
             # Get the pixel value. Need to flip Y as image coord is top-left.
             pixelVal = image[(image.shape[0] - 1) - self.mouse_pos_in_tex_coord[1], self.mouse_pos_in_tex_coord[0]]
             # Update info text
-            self.app.root.ids.middlecolumn.ids.pixelvalue.text = f'({self.mouse_pos_in_tex_coord[0]}, {self.mouse_pos_in_tex_coord[1]}, {pixelVal})'
+            self.app.root.ids.middlecolumn.ids.pixelvalue.text = f'x: {self.mouse_pos_in_tex_coord[0]}, y: {self.mouse_pos_in_tex_coord[1]}, intensity: {pixelVal}'
 
         return  
 
@@ -3758,7 +3758,10 @@ class GlowTrackerApp(App):
                 self.stage.stop(stopAxis= AxisEnum.Z)
                 self.coords = self.stage.get_position()
 
-        print(f'Stage position: {self.coords}')
+        stagePosString = f'Stage position: {self.coords[0]:.3f}, {self.coords[1]:.3f}'
+        if len(self.coords) > 2:
+            stagePosString += f', {self.coords[2]:.3f}'
+        print(stagePosString)
 
 
     def unbind_keys(self):

--- a/glowtracker/GlowTracker.py
+++ b/glowtracker/GlowTracker.py
@@ -1952,13 +1952,6 @@ class PreviewImage(Image):
         
         mouse_pos = np.array(pos, np.float32)
 
-        # Scale mouse position upto the display density factor.
-        #   This is usually 1 for normal monitor. 
-        #   But for higher density monitors like in modern laptop
-        #   or smartphone, this factor will be more than 1.
-        #   This is important because it affect the coordinate system down the line.
-        mouse_pos *= Metrics.dp
-
         previewImage = self
         scalableImage = self.app.root.ids.middlecolumn.ids.scalableimage    # parent of the previewImage
 

--- a/glowtracker/GlowTracker.py
+++ b/glowtracker/GlowTracker.py
@@ -1088,7 +1088,7 @@ class CameraProperties(GridLayout):
     def change_gain(self):
         camera = App.get_running_app().camera
         if camera is not None:
-            camera.Gain = float(self.gain)
+            camera.Gain.Value = float(self.gain)
             self.gain = camera.Gain()
         else:
             self.gain = 0
@@ -1097,7 +1097,7 @@ class CameraProperties(GridLayout):
     def change_exposure(self):
         camera = App.get_running_app().camera
         if camera is not None:
-            camera.ExposureTime = float(self.exposure)
+            camera.ExposureTime.Value = float(self.exposure)
             self.exposure = camera.ExposureTime()
         else:
             self.exposure = 0
@@ -1107,8 +1107,8 @@ class CameraProperties(GridLayout):
         """update framerate"""
         camera = App.get_running_app().camera
         if camera is not None:
-            camera.AcquisitionFrameRateEnable = True
-            camera.AcquisitionFrameRate = float(self.framerate)
+            camera.AcquisitionFrameRateEnable.Value = True
+            camera.AcquisitionFrameRate.Value = float(self.framerate)
             self.framerate = camera.ResultingFrameRate()
         else:
             self.framerate = 0
@@ -3002,22 +3002,22 @@ class RuntimeControls(BoxLayout):
             # Wait for camera acquisition to fully stop.
             time.sleep(2/camera.AcquisitionFrameRate()) # Wait 2 frame
             # grab unlock
-            camera.TLParamsLocked = False
+            camera.TLParamsLocked.Value = False
 
             # The Basler's camera have a feature-persistence feature, where the camera offset and width/height
             #   are checked against each other all the time so that the sum does not exceed the sensor's limit.
             #   Relaxing the offsets first allows setting any valid widhth/height.
-            camera.OffsetX = 0
-            camera.OffsetY = 0
-            camera.Width = int(cameraConfig['Width'])
-            camera.Height = int(cameraConfig['Height'])
-            camera.CenterX = bool(int(cameraConfig['CenterX']))
-            camera.CenterY = bool(int(cameraConfig['CenterY']))
-            camera.OffsetX = int(cameraConfig['OffsetX'])
-            camera.OffsetY = int(cameraConfig['OffsetY'])
+            camera.OffsetX.Value = 0
+            camera.OffsetY.Value = 0
+            camera.Width.Value = int(cameraConfig['Width'])
+            camera.Height.Value = int(cameraConfig['Height'])
+            camera.CenterX.Value = bool(int(cameraConfig['CenterX']))
+            camera.CenterY.Value = bool(int(cameraConfig['CenterY']))
+            camera.OffsetX.Value = int(cameraConfig['OffsetX'])
+            camera.OffsetY.Value = int(cameraConfig['OffsetY'])
 
             # grab lock
-            camera.TLParamsLocked = True
+            camera.TLParamsLocked.Value = True
             # cam start
             camera.AcquisitionStart.Execute()
             # Set camera on hold flag

--- a/glowtracker/GlowTracker.py
+++ b/glowtracker/GlowTracker.py
@@ -1520,13 +1520,6 @@ class RecordButton(ImageAcquisitionButton):
         # Disable LiveView
         imageAcquisitionManager.liveviewbutton.disabled = True
 
-        # Store previous Live Analysis state and set to enable
-        liveanalysisquickbutton: LiveAnalysisQuickButton = self.app.root.ids.middlecolumn.ids.runtimecontrols.ids.liveanalysisquickbutton
-
-        self.prevLiveAnalysisButtonState = liveanalysisquickbutton.state
-        if liveanalysisquickbutton.state == 'normal':
-            liveanalysisquickbutton.state = 'down'
-
         self.runtimeControls.framecounter.value = 0
 
         self.saveFilePath = self.app.root.ids.leftcolumn.savefile
@@ -1705,9 +1698,6 @@ class RecordButton(ImageAcquisitionButton):
             # LiveView
             self.parent.liveviewbutton.disabled = False
             self.parent.liveviewbutton.state = self.prevLiveViewButtonState
-            # LiveAnalysis
-            liveanalysisquickbutton: LiveAnalysisQuickButton = self.app.root.ids.middlecolumn.ids.runtimecontrols.ids.liveanalysisquickbutton
-            liveanalysisquickbutton.state = self.prevLiveAnalysisButtonState
         
         Clock.schedule_once( resumeButtonsState )
     
@@ -1730,9 +1720,9 @@ class RecordButton(ImageAcquisitionButton):
         #   - LiveAnalysisButton state is normal
         #   - showliveanalysis flag in the Settings is False.
         # In these cases, the base method would not have computed the Live Analysis values, so we just simply call it.
-        showliveanalysis = self.app.config.getboolean('LiveAnalysis', 'showliveanalysis')
-        if not showliveanalysis:
-            self.computeLiveAnalysisValues()
+        # showliveanalysis = self.app.config.getboolean('LiveAnalysis', 'showliveanalysis')
+        # if not showliveanalysis:
+        #     self.computeLiveAnalysisValues()
 
     
     @override

--- a/glowtracker/GlowTracker.py
+++ b/glowtracker/GlowTracker.py
@@ -106,7 +106,15 @@ def imageToTexture(image: np.ndarray) -> Texture:
         texture (Texture): image as a Kivy Texture
     """    
     height, width = image.shape[0], image.shape[1]
-    colorfmt = 'luminance' if image.ndim == 2 else 'rgb'
+    
+    colorfmt = 'luminance'
+    if image.ndim == 2:
+        colorfmt = 'luminance'
+    elif image.ndim == 3:
+        colorfmt = 'rgb'
+    elif image.ndim == 4:
+        colorfmt = 'rgba'
+        
     bufferfmt = 'ubyte'
     
     # Create a new Kivy Texture

--- a/glowtracker/Microscope_macros.py
+++ b/glowtracker/Microscope_macros.py
@@ -748,13 +748,13 @@ class CameraAndStageCalibrator:
         """        
 
         # Estimate camera basis X 
-        basisXPhaseShift, _, _ = phase_cross_correlation(self.basisOrigImage, self.basisXImage, upsample_factor= 1, space= 'real', return_error= 0, overlap_ratio= 0.5)    
+        basisXPhaseShift, _, _ = phase_cross_correlation(self.basisOrigImage, self.basisXImage, upsample_factor= 1, space= 'real', overlap_ratio= 0.5)    
     
         camBasisXVec = np.array([basisXPhaseShift[1], -basisXPhaseShift[0]], np.float32)
         camBasisXLen = np.linalg.norm(camBasisXVec)
 
         # Estimate camera basis Y
-        basisYPhaseShift, _, _ = phase_cross_correlation(self.basisOrigImage, self.basisYImage, upsample_factor= 1, space= 'real', return_error= 0, overlap_ratio= 0.5)    
+        basisYPhaseShift, _, _ = phase_cross_correlation(self.basisOrigImage, self.basisYImage, upsample_factor= 1, space= 'real', overlap_ratio= 0.5)    
     
         camBasisYVec = np.array([basisYPhaseShift[1], -basisYPhaseShift[0]], np.float32)
         camBasisYLen = np.linalg.norm(camBasisYVec)
@@ -882,7 +882,9 @@ class CameraAndStageCalibrator:
         canvas = FigureCanvasAgg(fig)
         canvas.draw()
         width, height = fig.get_size_inches() * fig.get_dpi()
-        image_array = np.frombuffer(canvas.tostring_rgb(), dtype='uint8').reshape(int(height), int(width), 3)
+        image_array = np.frombuffer(canvas.tostring_argb(), dtype='uint8').reshape(int(height), int(width), 4)
+        # Remove alpha channel at the front
+        image_array = image_array[:,:,1:4]
 
         return image_array
 
@@ -1225,7 +1227,9 @@ class DepthOfFieldEstimator:
         canvas = FigureCanvasAgg(fig)
         canvas.draw()
         width, height = fig.get_size_inches() * fig.get_dpi()
-        plotImage = np.frombuffer(canvas.tostring_rgb(), dtype='uint8').reshape(int(height), int(width), 3)
+        plotImage = np.frombuffer(canvas.tostring_argb(), dtype='uint8').reshape(int(height), int(width), 4)
+        # Remove alpha channel at the front
+        plotImage = plotImage[:,:,1:4]
 
         return plotImage
     

--- a/glowtracker/Zaber_control.py
+++ b/glowtracker/Zaber_control.py
@@ -224,13 +224,13 @@ class Stage:
         
         try:
             if pos_len >= 1 and self.axis_x is not None and position[0] != 0:
-                self.axis_x.move_absolute(position[0], units_from_literals(unit), wait_until_idle)
+                self.axis_x.move_absolute(float(position[0]), units_from_literals(unit), wait_until_idle)
 
             if pos_len >= 2 and self.axis_y is not None and position[1] != 0:
-                self.axis_y.move_absolute(position[1], units_from_literals(unit), wait_until_idle)
+                self.axis_y.move_absolute(float(position[1]), units_from_literals(unit), wait_until_idle)
             
             if pos_len == 3 and self.axis_z is not None and position[2] != 0:
-                self.axis_z.move_absolute(position[2], units_from_literals(unit), wait_until_idle)
+                self.axis_z.move_absolute(float(position[2]), units_from_literals(unit), wait_until_idle)
         
         except MotionLibException as e:
             print(e)
@@ -247,7 +247,7 @@ class Stage:
         """        
         try:
             if self.axis_x is not None:
-                self.axis_x.move_relative(step, units_from_literals(unit), wait_until_idle)
+                self.axis_x.move_relative(float(step), units_from_literals(unit), wait_until_idle)
 
         except MotionLibException as e:
             print(e)
@@ -262,7 +262,7 @@ class Stage:
         """
         try:
             if self.axis_y is not None:
-                self.axis_y.move_relative(step, units_from_literals(unit), wait_until_idle)
+                self.axis_y.move_relative(float(step), units_from_literals(unit), wait_until_idle)
         
         except MotionLibException as e:
             print(e)
@@ -277,7 +277,7 @@ class Stage:
         """
         try:
             if self.axis_z is not None:
-                self.axis_z.move_relative(step, units_from_literals(unit), wait_until_idle)
+                self.axis_z.move_relative(float(step), units_from_literals(unit), wait_until_idle)
         
         except MotionLibException as e:
             print(e)
@@ -298,13 +298,13 @@ class Stage:
         pos_len = len(steps) 
        
         if pos_len >= 1 and steps[0] != 0:
-            self.move_x(steps[0], unit = unit, wait_until_idle=wait_until_idle)
+            self.move_x(float(steps[0]), unit = unit, wait_until_idle=wait_until_idle)
 
         if pos_len >= 2 and steps[1] != 0:
-            self.move_y(steps[1], unit = unit, wait_until_idle=wait_until_idle)
+            self.move_y(float(steps[1]), unit = unit, wait_until_idle=wait_until_idle)
         
         if pos_len == 3 and steps[2] != 0:
-            self.move_z(steps[2], unit = unit, wait_until_idle=wait_until_idle)
+            self.move_z(float(steps[2]), unit = unit, wait_until_idle=wait_until_idle)
         
 
     def start_move(self, velocity: Vec3, unit: str = 'um/s') -> None:
@@ -318,15 +318,15 @@ class Stage:
             # Move each axis simultaneously
             if self.axis_x is not None and not self.state.isMoving_x and velocity[0] != 0:
                 self.state.isMoving_x = True
-                self.axis_x.move_velocity(velocity[0], units_from_literals(unit))
+                self.axis_x.move_velocity(float(velocity[0]), units_from_literals(unit))
             
             if self.axis_y is not None and not self.state.isMoving_y and velocity[1] != 0:
                 self.state.isMoving_y = True
-                self.axis_y.move_velocity(velocity[1], units_from_literals(unit))
+                self.axis_y.move_velocity(float(velocity[1]), units_from_literals(unit))
 
             if self.axis_z is not None and not self.state.isMoving_z and velocity[2] != 0:
                 self.state.isMoving_z = True
-                self.axis_z.move_velocity(velocity[2], units_from_literals(unit))
+                self.axis_z.move_velocity(float(velocity[2]), units_from_literals(unit))
         except MovementFailedException as e:
             print(e)
 

--- a/glowtracker/Zaber_control.py
+++ b/glowtracker/Zaber_control.py
@@ -1,10 +1,10 @@
 import asyncio
 from zaber_motion import Library, Units, MotionLibException, MovementFailedException, CommandFailedException
-from zaber_motion.units import units_from_literals
+from zaber_motion.units import units_from_literals, LITERALS_TO_UNITS, UnitsAndLiterals, Units
 from zaber_motion.ascii import Connection, Axis, Device
 from dataclasses import dataclass
 import math
-from typing import List, Tuple, TypeAlias
+from typing import List, Tuple, TypeAlias, Literal
 from enum import Enum
 
 # Default settings
@@ -17,6 +17,19 @@ DEFAULT_ACCEL_UNIT = 'mm/s^2'
 Vec3: TypeAlias = Tuple[float, float, float]
 
 Library.enable_device_db_store()
+
+# Unit conversion
+UNITS_TO_LITERALS = {value: key for key, value in LITERALS_TO_UNITS.items()}
+
+def units_to_literals(units: UnitsAndLiterals) -> str:
+    if isinstance(units, str):
+        return units
+
+    converted = UNITS_TO_LITERALS.get(units)
+    if converted is None:
+        raise ValueError(f"Invalid units: {units}")
+
+    return converted
 
 @dataclass
 class StageState:
@@ -145,7 +158,7 @@ class Stage:
 
             # Retrieve actual axis max speed
             self.maxspeed = axis.settings.get("maxspeed", unit)
-            print(f'Maximum speed: {self.maxspeed}[{unit}]')
+            print(f'Maximum speed: {self.maxspeed:.4f} {units_to_literals(unit)}')
             
         return self.maxspeed
     
@@ -180,7 +193,7 @@ class Stage:
 
             # Retrieve actual axis acceleration 
             self.accel = axis.settings.get("accel", units_from_literals(unit))
-            print(f'Acceleration: {self.accel}[{unit}]')
+            print(f'Acceleration: {self.accel:.4f} {units_to_literals(unit)}')
 
         return self.accel
 

--- a/glowtracker/layout.kv
+++ b/glowtracker/layout.kv
@@ -495,7 +495,7 @@ MainWindow:
             pos_hint: {'right': 1}
             text_size: self.size
             id: pixelvalue
-            text: '(0, 0, 0)'
+            text: 'x:0, y:0, intensity:0'
             halign: 'right'
         
     RuntimeControls:

--- a/glowtracker/layout.kv
+++ b/glowtracker/layout.kv
@@ -34,7 +34,7 @@ MainWindow:
                 font_size: 18
                 color: '#8e0045ff'
 
-                text: "v. 0.11.0"
+                text: "v. 0.12.0"
                 id: versionlabel
 
                 pos_hint: {'x':.0, 'y':.0}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ glowtracker = [
 
 [project]
 name = "glowtracker"
-version = "0.11.0"
+version = "0.12.0"
 description = "GlowTracker provides a graphical user interface to operate a microscope. The microscope is a hardware setup designed for tracking a small animal in bright field, single or dual epi-fluorescence imaging."
 authors = [
     { name="Monika Scholz", email="monika.scholz@mpinb.mpg.de" }
@@ -34,28 +34,27 @@ maintainers = [
     { name="Takkasila Saichol", email="takkasila.saichol@mpinb.mpg.de" }
 ]
 readme = "README.md"
-license = {file = "LICENSE.txt"}
+license-files = ["LICENSE.txt"]
 requires-python = ">=3.10"
 dependencies = [
-    "kivy==2.2.1",
-    "matplotlib==3.7.2",
-    "numpy==1.25.1",
-    "opencv-python==4.7.0.72",
-    "pillow==10.0.0",
-    "scikit-image==0.22.0",
-    "scipy==1.11.1",
-    "zaber-motion==4.2.0",
-    "overrides==7.7.0",
-    "pandas==2.2.0",
-    "pypylon==2.2.0",
-    "itk-elastix==0.19.0",
-    "platformdirs==3.9.1",
-    "pyparsing==3.0.9"
+    "kivy>=2.2.0",
+    "matplotlib",
+    "numpy",
+    "opencv-python",
+    "pillow",
+    "scikit-image>=0.22.0",
+    "scipy",
+    "zaber-motion",
+    "overrides",
+    "pandas",
+    "pypylon",
+    "itk-elastix",
+    "platformdirs",
+    "pyparsing"
 ]
 classifiers = [
     "Intended Audience :: Science/Research",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
     "Topic :: Scientific/Engineering :: Bio-Informatics",
     "Topic :: Scientific/Engineering :: Image Recognition",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = ["setuptools>=64.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]


### PR DESCRIPTION
- Updated GlowTracker to support Python version 3.10, 3.11, 3.12, 3.13
- Updated deprecated functions' argument
- Updated github actions to test install on all the above versions.
- Added installattion instruction for uv
- Bumped up the version to 0.12.0
- Fixed Zaber movement functions not supporting Numpy as input
- Fixed Live Analysis executes at recording even if disabled
- Fixed Baseler deprecated direct camera's attribute setting
- Removed mouse position scaling by monitor display density pixel beause it is automatically done for newer version.