### PR TITLE
DAQ Controller 

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -17,6 +17,12 @@ We can test the package by install directly and locally form
 ```bash
 python -m pip install dist/glowtracker-[version].tar.gz
 ```
+or
+```bash
+uv pip install dist/glowtracker-[version].tar.gz
+```
+Add `--python 3.10` to select a specific python version e.g. 3.10
+
 
 # Running
 Once the package is installed, the application can be started by

--- a/glowtracker/Basler_control.py
+++ b/glowtracker/Basler_control.py
@@ -49,7 +49,7 @@ class Camera(pylon.InstantCamera):
             camera.Open()
             
             # Print the model name of the camera.
-            print("Using device ", camera.GetDeviceInfo().GetModelName())
+            print("Using device", camera.GetDeviceInfo().GetModelName())
 
             return camera
 

--- a/glowtracker/Basler_control.py
+++ b/glowtracker/Basler_control.py
@@ -343,15 +343,13 @@ def readPFSFile(filepath: str) -> Dict[str, str] | None:
                 if line.startswith('#'):
                     continue
 
-                parts = line.split(None, 1)
-                if len(parts) == 2:
-                    key, value = parts
-                    parsedDict[key] = value
+                # Split words (separate by blanks)
+                parts = line.split()
                 
-                else:
-                    print(f'Error: Parsing {filepath}. Format is not supported')
-                    return None
-        
+                key = parts[0]
+                value = parts[-1]
+                parsedDict[key] = value
+
             return parsedDict
 
     except FileNotFoundError:

--- a/glowtracker/DAQ_control.py
+++ b/glowtracker/DAQ_control.py
@@ -69,7 +69,6 @@ class DAQControl():
         # self.isEnable: bool = False
         self.ledsMode: LEDsMode = LEDsMode.Off
         self.sequencerMode: SequencerMode = SequencerMode.Frame
-        self.stageProgramMode: StageProgramMode = StageProgramMode.FourPoint
         self.daqStageProgram: DAQStageProgram = DAQStageProgram()
 
 
@@ -246,31 +245,43 @@ class DAQControl():
 class DAQStageProgram():
 
     def __init__(self):
+        self.mode: StageProgramMode = StageProgramMode.FourPoint
         self.quadVertex: List[Vertex2D] = []
         self.exterior = Exterior.Zero
         self.exteriorConstant: float = 0
     
     
-    def update(self, quadVertex: List[Vertex2D], exterior: Exterior, exteriorConstant: float) -> None:
-        """Parse variables and sort vertices in anti-clockwise order.
+    def update(self, mode: StageProgramMode = None, quadVertex: List[Vertex2D] = None, exterior: Exterior = None, exteriorConstant: float = None) -> None:
+        """Parse variables and process them.
 
         Args:
-            quadVertex (List[Vertex2D]): _description_
-            exterior (Exterior): _description_
-            exteriorConstant (float): _description_
+            mode (StageProgramMode): StageProgram mode
+            quadVertex (List[Vertex2D]): A list of four Vertex2D
+            exterior (Exterior): Exterior mode
+            exteriorConstant (float): Constant exterior value in case Exterior mode is Constant.
         """
 
-        self.quadVertex = quadVertex
-        self.exterior = exterior
-        self.exteriorConstant = exteriorConstant
+        if mode:
+            self.mode = mode
+        
+        if quadVertex:
+            self.quadVertex = quadVertex
 
-        center = np.zeros([2], np.float32)
-        for vert in quadVertex:
-            center = center + vert.point
-        center = center / 4
+            # Sort points in anti-clockwise order starting from btmLeft: btmLeft, btmRight, topRight, topRight
+            #   Compute center
+            center = np.zeros([2], np.float32)
+            for vert in quadVertex:
+                center = center + vert.point
+            center = center / 4
 
-        # Sort points in anti-clockwise order starting from btmLeft: btmLeft, btmRight, topRight, topRight
-        self.quadVertex.sort(key= lambda vertex: math.atan2(vertex.point[1] - center[1], vertex.point[0] - center[0]))
+            #   Sort
+            self.quadVertex.sort(key= lambda vertex: math.atan2(vertex.point[1] - center[1], vertex.point[0] - center[0]))
+        
+        if exterior:
+            self.exterior = exterior
+        
+        if exteriorConstant:
+            self.exteriorConstant = exteriorConstant
     
     
     def getValue(self, x: float, y: float) -> float:
@@ -284,7 +295,14 @@ class DAQStageProgram():
             float: bilinear-interpolated voltage
         """
 
-        val = Vertex2D.bilerp(self.quadVertex[0], self.quadVertex[1], self.quadVertex[2], self.quadVertex[3], np.array([x, y], np.float32), self.exterior, self.exteriorConstant)
+        val = 0
+
+        if self.mode == StageProgramMode.FourPoint:
+            val = Vertex2D.bilerp(self.quadVertex[0], self.quadVertex[1], self.quadVertex[2], self.quadVertex[3], np.array([x, y], np.float32), self.exterior, self.exteriorConstant)
+        
+        elif self.mode == StageProgramMode.Gaussian:
+            # TODO:
+            pass
 
         # Clamp between 0, 5 vol
         val = min(max(0, val), 5)
@@ -339,5 +357,8 @@ class DAQStageProgram():
         imageArr = np.frombuffer(canvas.tostring_argb(), dtype='uint8').reshape(int(height), int(width), 4)
         # Remove alpha channel at the front
         imageArr = imageArr[:,:,1:4]
+
+        # Finally close the figure
+        plt.close(fig= fig)
 
         return imageArr

--- a/glowtracker/DAQ_control.py
+++ b/glowtracker/DAQ_control.py
@@ -429,7 +429,6 @@ class DAQStageProgram():
 
         im = plt.imshow(valMap, cmap= 'magma', extent= extent)
         plt.colorbar(im)
-        plt.gca().set_facecolor("yellow")
         
         # Plot landmarks
         def drawPointWithAnnotation(point: List[float], color: str, name: str) -> None:
@@ -450,16 +449,51 @@ class DAQStageProgram():
 
         # Set plot limits and labels
         if isRelativeToStart:
-            plt.xlim(-stageRange[0], stageRange[0])
-            plt.ylim(-stageRange[1], stageRange[1])
 
+            # Find min, max
+            btmLeft = np.zeros([2], np.float32)
+            topRight = np.zeros([2], np.float32)
+
+            if self.mode == StageProgramMode.FourPoint:
+                
+                for vertex in self.quadVertex:
+                    btmLeft = np.where(btmLeft > vertex.point, vertex.point, btmLeft)
+                    topRight = np.where(topRight < vertex.point, vertex.point, topRight)
+
+
+            elif self.mode == StageProgramMode.Gaussian:
+
+                span = 2
+
+                btmLeft[0] = -self.gaussianParams.x_sigma * span + self.gaussianParams.x_mean
+                btmLeft[1] = -self.gaussianParams.y_sigma * span + self.gaussianParams.y_mean
+                topRight[0] = self.gaussianParams.x_sigma * span + self.gaussianParams.x_mean
+                topRight[1] = self.gaussianParams.y_sigma * span + self.gaussianParams.y_mean
+
+                # Also check bound with origin
+                btmLeft = np.where(btmLeft > np.zeros([2]), np.zeros([2]), btmLeft)
+                topRight = np.where(topRight < np.zeros([2]), np.zeros([2]), topRight)
+                
+
+            # Add padding
+            btmLeft = btmLeft - 10
+            topRight = topRight + 10
+            
+            plt.xlim(btmLeft[0], topRight[0])
+            plt.ylim(btmLeft[1], topRight[1])
+            
         else:
             plt.xlim(0, stageRange[0])
             plt.ylim(0, stageRange[1])
 
         plt.xlabel('Stage X (mm)')
         plt.ylabel('Stage Y (mm)')
-        plt.title("Stage position to Voltage map")
+
+        title = "Stage position to Voltage map"
+        if isRelativeToStart:
+            title = "Relative stage-position to Voltage map"
+
+        plt.title(title)
 
         # Add grid and legend
         plt.grid(True)

--- a/glowtracker/DAQ_control.py
+++ b/glowtracker/DAQ_control.py
@@ -10,11 +10,11 @@ class DAQControl():
 
     @classmethod
     def createAndConnectDaq(cls) -> DAQControl | None:
-        """Create a Camera class object. Return the object if the connection to the actual camera
+        """Create a DAQControl class object. Return the object if the connection to the actual DAQ
         is successful. Otherwise, return None.
 
         Returns:
-            camera (Camera|None): Camera(pylon.InstantCamera) class if successful, otherwise None.
+            DAQControl (DAQControl|None): DAQControl class if successful, otherwise None.
         """
         try:
             # Connect to DAQ
@@ -42,12 +42,18 @@ class DAQControl():
     def __init__(self):
         self.daq: u3.U3 | None = None
         self.ledsSequnceDict : dict | None = None
+        self.isEnable: bool = False
 
     
     def close(self):
         # Check if Windows then call LabJackPython.Close(), else call self.daq.close()
         self.daq.close()
         self.daq = None
+
+    
+    def reset(self):
+        # Set to factory default
+        self.daq.setDefaults()
 
         
     def parseTextScript(self, text: str) -> None:
@@ -71,7 +77,7 @@ class DAQControl():
 
     def triggerCommand(self, frameNum: int) -> None:
         
-        if self.ledsSequnceDict is None:
+        if self.ledsSequnceDict is None or not self.isEnable:
             return
         
         frameCommand = self.ledsSequnceDict.get(frameNum)

--- a/glowtracker/DAQ_control.py
+++ b/glowtracker/DAQ_control.py
@@ -40,17 +40,13 @@ class DAQControl():
         Returns:
             DAQControl (DAQControl|None): DAQControl class if successful, otherwise None.
         """
+        daqControl = DAQControl()
+
         try:
             # Connect to DAQ
             daq = u3.U3(debug= False)
 
-        except Exception as e:
-            print(e)
-            return None
-
-        else:
             # Instantiate DAQConatrol object
-            daqControl = DAQControl()
             daqControl.daq = daq
             
             print(f"Using {daqControl.daq.deviceName}, serial: {daqControl.daq.serialNumber}")
@@ -60,6 +56,10 @@ class DAQControl():
             # Calibrate
             daqControl.daq.getCalibrationData()
 
+        except Exception as e:
+            print(e)
+        
+        finally:
             return daqControl
 
 
@@ -71,12 +71,17 @@ class DAQControl():
         self.ledsMode: LEDsMode = LEDsMode.Off
         self.sequencerMode: SequencerMode = SequencerMode.Frame
         self.daqStageProgram: DAQStageProgram = DAQStageProgram()
+    
+
+    def isConnected(self) -> bool:
+        return self.daq is not None
 
 
     def close(self):
-        # Check if Windows then call LabJackPython.Close(), else call self.daq.close()
-        self.daq.close()
-        self.daq = None
+        if self.isConnected():
+            # Check if Windows then call LabJackPython.Close(), else call self.daq.close()
+            self.daq.close()
+            self.daq = None
 
     
     def start(self):
@@ -88,8 +93,9 @@ class DAQControl():
     def reset(self):
         """Set DAQ values to factory default. Should be call after finished executing a command list.
         """
-        if self.daq is None:
+        if not self.isConnected():
             return
+
         # Set to factory default
         self.daq.setDefaults(SetToFactoryDefaults= True)
         # Manually set DAC0 to 0 (off)

--- a/glowtracker/DAQ_control.py
+++ b/glowtracker/DAQ_control.py
@@ -113,7 +113,7 @@ class DAQControl():
             preprocessdText = "{\n" + ",\n".join(lines) + "\n}"
             
             # Parse the text to be a dict object. Highlight keywords "on", "off"
-            processedDict = eval(preprocessdText, globals= {
+            processedDict = eval(preprocessdText, {
                 "on": "on", 
                 "off": "off", 
                 "mode": "mode",

--- a/glowtracker/DAQ_control.py
+++ b/glowtracker/DAQ_control.py
@@ -13,9 +13,6 @@ class TriggerUpdateMode(StrEnum):
 
 class DAQControl():
 
-    HIGH = 1
-    LOW = 0
-
     @classmethod
     def createAndConnectDaq(cls) -> DAQControl | None:
         """Create a DAQControl class object. Return the object if the connection to the actual DAQ

--- a/glowtracker/DAQ_control.py
+++ b/glowtracker/DAQ_control.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+import LabJackPython
+import u3
+import re
+
+class DAQControl():
+
+    HIGH = 1
+    LOW = 0
+
+    @classmethod
+    def createAndConnectDaq(cls) -> DAQControl | None:
+        """Create a Camera class object. Return the object if the connection to the actual camera
+        is successful. Otherwise, return None.
+
+        Returns:
+            camera (Camera|None): Camera(pylon.InstantCamera) class if successful, otherwise None.
+        """
+        try:
+            # Connect to DAQ
+            daq = u3.U3(debug= False)
+
+        except Exception as e:
+            print(e)
+            return None
+
+        else:
+            # Instantiate DAQConatrol object
+            daqControl = DAQControl()
+            daqControl.daq = daq
+            
+            print(f"Using {daqControl.daq.deviceName}, serial: {daqControl.daq.serialNumber}")
+            
+            # Set to factory default
+            daqControl.daq.setDefaults()
+            # Calibrate
+            daqControl.daq.getCalibrationData()
+
+            return daqControl
+
+
+    def __init__(self):
+        self.daq: u3.U3 | None = None
+        self.ledsSequnceDict : dict | None = None
+
+    
+    def close(self):
+        # Check if Windows then call LabJackPython.Close(), else call self.daq.close()
+        self.daq.close()
+        self.daq = None
+
+        
+    def parseTextScript(self, text: str) -> None:
+
+        try:
+            # Remove empty lines and surrounding whitespace
+            lines = [line.strip() for line in text.splitlines() if line.strip()]
+
+            # Remove trailing commas from each line
+            lines = [re.sub(r',$', '', line) for line in lines]
+
+            # Wrap into a dict literal
+            preprocessdText = "{\n" + ",\n".join(lines) + "\n}"
+            
+            # Parse the text to be a dict object. Highlight keywords "on", "off"
+            self.ledsSequnceDict = eval(preprocessdText, globals= {"on": "on", "off": "off"})
+        
+        except Exception as e:
+            raise ValueError(f"Failed to parse LED script text: {e}") from None
+    
+
+    def triggerCommand(self, frameNum: int) -> None:
+        
+        if self.ledsSequnceDict is None:
+            return
+        
+        frameCommand = self.ledsSequnceDict.get(frameNum)
+
+        if frameCommand is None:
+            return
+
+        command: list = frameCommand[0]
+
+        if command == 'on':
+            if len(frameCommand) != 2:
+                print("\"on\" command requires a voltage argument.")
+                return
+            
+            vol = frameCommand[1]
+
+            # Clip to 0, 4.95
+            vol = max( min( vol, 4.95 ), 0 )
+
+            print(f"Turn on the light! {vol}")
+
+            # Send command to DAQ at DAC0
+            dac0Val = self.daq.voltageToDACBits(volts= vol, dacNumber= 0, is16Bits= False)
+            dac0Command = u3.DAC0_8(dac0Val)
+            self.daq.getFeedback(dac0Command)
+            
+        
+        elif command == 'off':
+            
+            print(f"Turn off the light!")
+
+            # Send command to DAQ at DAC0
+            dac0Val = self.daq.voltageToDACBits(volts= 0, dacNumber= 0, is16Bits= False)
+            dac0Command = u3.DAC0_8(dac0Val)
+            self.daq.getFeedback(dac0Command)
+        

--- a/glowtracker/DAQ_control.py
+++ b/glowtracker/DAQ_control.py
@@ -11,6 +11,7 @@ import numpy as np
 import math
 from matplotlib import pyplot as plt
 from matplotlib.backends.backend_agg import FigureCanvasAgg
+from dataclasses import dataclass
 
 
 class LEDsMode(StrEnum):
@@ -242,6 +243,15 @@ class DAQControl():
             self.daq.getFeedback(dac0Command)
 
 
+@dataclass
+class GaussianParams():
+    amplitude: float = 0
+    x_mean: float = 0
+    x_sigma: float = 0
+    y_mean: float = 0
+    y_sigma: float = 0
+
+
 class DAQStageProgram():
 
     def __init__(self):
@@ -249,9 +259,10 @@ class DAQStageProgram():
         self.quadVertex: List[Vertex2D] = []
         self.exterior = Exterior.Zero
         self.exteriorConstant: float = 0
+        self.gaussianParams = GaussianParams()
     
     
-    def update(self, mode: StageProgramMode = None, quadVertex: List[Vertex2D] = None, exterior: Exterior = None, exteriorConstant: float = None) -> None:
+    def update(self, mode: StageProgramMode = None, quadVertex: List[Vertex2D] = None, exterior: Exterior = None, exteriorConstant: float = None, gaussianParams: GaussianParams = None) -> None:
         """Parse variables and process them.
 
         Args:
@@ -282,6 +293,9 @@ class DAQStageProgram():
         
         if exteriorConstant:
             self.exteriorConstant = exteriorConstant
+        
+        if gaussianParams:
+            self.gaussianParams = gaussianParams
     
     
     def getValue(self, x: float, y: float) -> float:
@@ -298,11 +312,21 @@ class DAQStageProgram():
         val = 0
 
         if self.mode == StageProgramMode.FourPoint:
+
             val = Vertex2D.bilerp(self.quadVertex[0], self.quadVertex[1], self.quadVertex[2], self.quadVertex[3], np.array([x, y], np.float32), self.exterior, self.exteriorConstant)
+
         
         elif self.mode == StageProgramMode.Gaussian:
-            # TODO:
-            pass
+
+            if not (math.isclose(self.gaussianParams.x_sigma, 0.0) or math.isclose(self.gaussianParams.y_sigma, 0.0)):
+                val = (
+                    self.gaussianParams.amplitude
+                    / (2 * np.pi * self.gaussianParams.x_sigma * self.gaussianParams.y_sigma)
+                    * np.exp(
+                        -((x - self.gaussianParams.x_mean)**2 / (2 * (self.gaussianParams.x_sigma**2)))
+                        -((y - self.gaussianParams.y_mean)**2 / (2 * (self.gaussianParams.y_sigma**2)))
+                    )
+                )
 
         # Clamp between 0, 5 vol
         val = min(max(0, val), 5)
@@ -325,6 +349,7 @@ class DAQStageProgram():
             
         
         # Create the plot
+        plt.ioff()
         fig = plt.figure(figsize=(6, 6))
         
         # Plot map
@@ -336,16 +361,21 @@ class DAQStageProgram():
             plt.scatter(point[0], point[1], c= color)
             plt.annotate(name, (point[0], point[1]), textcoords= 'offset points', xytext= (10,10), ha= 'center', fontsize= 12, color= 'green')
         
-        drawPointWithAnnotation(self.quadVertex[0].point, 'r', self.quadVertex[0].name)
-        drawPointWithAnnotation(self.quadVertex[1].point, 'r', self.quadVertex[1].name)
-        drawPointWithAnnotation(self.quadVertex[2].point, 'r', self.quadVertex[2].name)
-        drawPointWithAnnotation(self.quadVertex[3].point, 'r', self.quadVertex[3].name)
+        if self.mode == StageProgramMode.FourPoint:
+            drawPointWithAnnotation(self.quadVertex[0].point, 'r', self.quadVertex[0].name)
+            drawPointWithAnnotation(self.quadVertex[1].point, 'r', self.quadVertex[1].name)
+            drawPointWithAnnotation(self.quadVertex[2].point, 'r', self.quadVertex[2].name)
+            drawPointWithAnnotation(self.quadVertex[3].point, 'r', self.quadVertex[3].name)
+        
+        elif self.mode == StageProgramMode.Gaussian:
+            drawPointWithAnnotation([self.gaussianParams.x_mean, self.gaussianParams.y_mean], 'r', 'Mean')
 
         # Set plot limits and labels
         plt.xlim(0, 160)
         plt.ylim(0, 160)
-        plt.xlabel('X')
-        plt.ylabel('Y')
+        plt.xlabel('Stage X (mm)')
+        plt.ylabel('Stage Y (mm)')
+        plt.title("Stage position to Voltage map")
 
         # Add grid and legend
         plt.grid(True)
@@ -360,5 +390,6 @@ class DAQStageProgram():
 
         # Finally close the figure
         plt.close(fig= fig)
+        plt.ion()
 
         return imageArr

--- a/glowtracker/DAQ_control.py
+++ b/glowtracker/DAQ_control.py
@@ -88,6 +88,8 @@ class DAQControl():
     def reset(self):
         """Set DAQ values to factory default. Should be call after finished executing a command list.
         """
+        if self.daq is None:
+            return
         # Set to factory default
         self.daq.setDefaults(SetToFactoryDefaults= True)
         # Manually set DAC0 to 0 (off)
@@ -319,15 +321,16 @@ class DAQStageProgram():
         elif self.mode == StageProgramMode.Gaussian:
 
             if not (math.isclose(self.gaussianParams.x_sigma, 0.0) or math.isclose(self.gaussianParams.y_sigma, 0.0)):
+
+                # Compute normalized gaussian distribution
                 val = (
                     self.gaussianParams.amplitude
-                    / (2 * np.pi * self.gaussianParams.x_sigma * self.gaussianParams.y_sigma)
                     * np.exp(
                         -((x - self.gaussianParams.x_mean)**2 / (2 * (self.gaussianParams.x_sigma**2)))
                         -((y - self.gaussianParams.y_mean)**2 / (2 * (self.gaussianParams.y_sigma**2)))
                     )
                 )
-
+                
         # Clamp between 0, 5 vol
         val = min(max(0, val), 5)
 

--- a/glowtracker/DAQ_control.py
+++ b/glowtracker/DAQ_control.py
@@ -84,10 +84,11 @@ class DAQControl():
             self.daq = None
 
     
-    def start(self):
+    def start(self, startRecordPosition: np.ndarray):
         """Reset internal command dict to original to prepare for running.
         """
         self.ledsSequnceDictRunning = deepcopy(self.ledsSequnceDict)
+        self.daqStageProgram.startRecordPosition = startRecordPosition
     
     
     def reset(self):
@@ -104,6 +105,7 @@ class DAQControl():
         self.daq.getFeedback(dac0Command)
         # Clean running command queue
         self.ledsSequnceDictRunning.clear()
+        self.daqStageProgram.startRecordPosition = np.zeros([2], np.float32)
 
         
     def parseTextScript(self, text: str) -> None:
@@ -269,6 +271,7 @@ class DAQStageProgram():
         self.exteriorConstant: float = 0
         self.gaussianParams = GaussianParams()
         self.isGaussianRelative = False
+        self.startRecordPosition = np.zeros([2], np.float32)
     
     
     def update(
@@ -314,7 +317,7 @@ class DAQStageProgram():
         if gaussianParams:
             self.gaussianParams = gaussianParams
         
-        if isGaussianRelative:
+        if isGaussianRelative is not None: 
             self.isGaussianRelative = isGaussianRelative
     
     
@@ -340,12 +343,21 @@ class DAQStageProgram():
 
             if not (math.isclose(self.gaussianParams.x_sigma, 0.0) or math.isclose(self.gaussianParams.y_sigma, 0.0)):
 
+                currentPosition = np.array([x, y], np.float32)
+
+                if self.isGaussianRelative:
+                    currentPosition = currentPosition - self.startRecordPosition
+
+                gMeans = np.array([self.gaussianParams.x_mean, self.gaussianParams.y_mean], np.float32)
+
+                distance = currentPosition - gMeans
+
                 # Compute normalized gaussian distribution
                 val = (
                     self.gaussianParams.amplitude
                     * np.exp(
-                        -((x - self.gaussianParams.x_mean)**2 / (2 * (self.gaussianParams.x_sigma**2)))
-                        -((y - self.gaussianParams.y_mean)**2 / (2 * (self.gaussianParams.y_sigma**2)))
+                        -((distance[0])**2 / (2 * (self.gaussianParams.x_sigma**2)))
+                        -((distance[1])**2 / (2 * (self.gaussianParams.y_sigma**2)))
                     )
                 )
                 
@@ -361,23 +373,44 @@ class DAQStageProgram():
         Returns:
             np.ndarray: RGB image of the plot
         """
+        stageRange = [160, 160]
         
+        # Allocate value map
+        valMapShape = [stageRange[0] + 1, stageRange[1] + 1, 1]
+        if self.isGaussianRelative:
+            valMapShape = [stageRange[0]*2 + 1, stageRange[1]*2 + 1, 1]
+        
+        valMap = np.zeros(valMapShape)
+
         # Compute value map
-        valMap = np.zeros([160 + 1, 160 + 1, 1], np.float32)
-        for y in range(valMap.shape[0]):
-            for x in range(valMap.shape[1]):
-                valMap[y, x] = self.getValue(x, y)
-            
+        for j in range(valMap.shape[0]):
+
+            y = j
+            if self.isGaussianRelative:
+                y = y - stageRange[0]
+                
+            for i in range(valMap.shape[1]):
+
+                x = i
+                if self.isGaussianRelative:
+                    x = x - stageRange[1]
+
+                valMap[j, i] = self.getValue(x, y)
         
         # Create the plot
         plt.ioff()
         fig = plt.figure(figsize=(6, 6))
         
         # Plot map
-        im = plt.imshow(valMap, cmap= 'magma')
+        extent = None
+        if self.isGaussianRelative:
+            extent = (-stageRange[0], stageRange[0], stageRange[1], -stageRange[1])
+
+        im = plt.imshow(valMap, cmap= 'magma', extent= extent)
         plt.colorbar(im)
+        plt.gca().set_facecolor("yellow")
         
-        # Plot 4 points
+        # Plot landmarks
         def drawPointWithAnnotation(point: List[float], color: str, name: str) -> None:
             plt.scatter(point[0], point[1], c= color)
             plt.annotate(name, (point[0], point[1]), textcoords= 'offset points', xytext= (10,10), ha= 'center', fontsize= 12, color= 'green')
@@ -390,10 +423,19 @@ class DAQStageProgram():
         
         elif self.mode == StageProgramMode.Gaussian:
             drawPointWithAnnotation([self.gaussianParams.x_mean, self.gaussianParams.y_mean], 'r', 'Mean')
+        
+        if self.isGaussianRelative:
+            drawPointWithAnnotation([0, 0], 'r', 'Start Pos')
 
         # Set plot limits and labels
-        plt.xlim(0, 160)
-        plt.ylim(0, 160)
+        if self.isGaussianRelative:
+            plt.xlim(-stageRange[0], stageRange[0])
+            plt.ylim(-stageRange[1], stageRange[1])
+
+        else:
+            plt.xlim(0, stageRange[0])
+            plt.ylim(0, stageRange[1])
+
         plt.xlabel('Stage X (mm)')
         plt.ylabel('Stage Y (mm)')
         plt.title("Stage position to Voltage map")

--- a/glowtracker/DAQ_control.py
+++ b/glowtracker/DAQ_control.py
@@ -265,7 +265,7 @@ class GaussianParams():
 class DAQStageProgram():
 
     def __init__(self):
-        self.mode: StageProgramMode = StageProgramMode.FourPoint
+        self.mode: StageProgramMode = StageProgramMode.Gaussian
         self.quadVertex: List[Vertex2D] = []
         self.exterior = Exterior.Zero
         self.exteriorConstant: float = 0

--- a/glowtracker/DAQ_control.py
+++ b/glowtracker/DAQ_control.py
@@ -6,9 +6,20 @@ from enum import StrEnum
 from collections import OrderedDict
 from copy import deepcopy
 
-class TriggerUpdateMode(StrEnum):
+class LEDsMode(StrEnum):
+    Off = 'Off'
+    Sequencer = 'Sequencer'
+    StageProgram = 'StageProgram'
+
+
+class SequencerMode(StrEnum):
     Frame = 'Frame'
     Time = 'Time'
+
+
+class StageProgramMode(StrEnum):
+    FourPoint = 'FourPoint'
+    Gaussian = 'Gaussian'
 
 
 class DAQControl():
@@ -48,10 +59,18 @@ class DAQControl():
         self.daq: u3.U3 | None = None
         self.ledsSequnceDict : OrderedDict = OrderedDict()
         self.ledsSequnceDictRunning : OrderedDict = OrderedDict()
-        self.isEnable: bool = False
-        self.mode: TriggerUpdateMode = TriggerUpdateMode.Frame
+        # self.isEnable: bool = False
+        self.ledsMode: LEDsMode = LEDsMode.Off
+        self.sequencerMode: SequencerMode = SequencerMode.Frame
+        self.stageProgramMode: StageProgramMode = StageProgramMode.FourPoint
 
-    
+        # LedsStageProgramWidget ?
+        #   We want to evalute this
+        #       val = Vertex2D.bilerp(self.quadVertex[0], self.quadVertex[1], self.quadVertex[2], self.quadVertex[3], np.array([x, y], np.float32), self.exterior, self.exteriorConstant)
+        #       Or even
+        #       val = Gaussian distance or something
+        #
+
     def close(self):
         # Check if Windows then call LabJackPython.Close(), else call self.daq.close()
         self.daq.close()
@@ -110,10 +129,10 @@ class DAQControl():
             self.ledsSequnceDict = OrderedDict( {key:val for key, val in sorted(processedDict.items(), key= lambda x: x[0])} )
 
             if mode == 'frame':
-                self.mode = TriggerUpdateMode.Frame
+                self.sequencerMode = SequencerMode.Frame
 
             elif mode == 'time':
-                self.mode = TriggerUpdateMode.Time
+                self.sequencerMode = SequencerMode.Time
                 
             else:
                 raise ValueError(f"Failed to parse LED script text: Invalid 'mode' argument. Options are ['frame', 'time']")
@@ -124,10 +143,10 @@ class DAQControl():
 
     def triggerCommand(self, frameNum: int = 0, frameTime: float = 0) -> None:
         
-        if len(self.ledsSequnceDictRunning) == 0 or not self.isEnable:
+        if len(self.ledsSequnceDictRunning) == 0 or not self.ledsMode == LEDsMode.Sequencer:
             return
 
-        if self.mode == TriggerUpdateMode.Frame:
+        if self.sequencerMode == SequencerMode.Frame:
         
             # Get the exact frame command
             frameCommand = self.ledsSequnceDictRunning.pop(frameNum, default= None)
@@ -136,7 +155,7 @@ class DAQControl():
                 print(f"Frame {frameNum}:")
                 self._executeCommand(frameCommand)
         
-        elif self.mode == TriggerUpdateMode.Time:
+        elif self.sequencerMode == SequencerMode.Time:
             
             # Get the first (lowest frame time) command in queue
             commandFrameTime = next(iter(self.ledsSequnceDictRunning))

--- a/glowtracker/DAQ_control.py
+++ b/glowtracker/DAQ_control.py
@@ -269,6 +269,7 @@ class DAQStageProgram():
         self.quadVertex: List[Vertex2D] = []
         self.exterior = Exterior.Zero
         self.exteriorConstant: float = 0
+        self.isFourPointRelative = False
         self.gaussianParams = GaussianParams()
         self.isGaussianRelative = False
         self.startRecordPosition = np.zeros([2], np.float32)
@@ -280,6 +281,7 @@ class DAQStageProgram():
             quadVertex: List[Vertex2D] | None = None, 
             exterior: Exterior | None = None, 
             exteriorConstant: float | None = None, 
+            isFourPointRelative: bool | None = None,
             gaussianParams: GaussianParams | None = None, 
             isGaussianRelative: bool | None = None
         ) -> None:
@@ -314,6 +316,9 @@ class DAQStageProgram():
         if exteriorConstant:
             self.exteriorConstant = exteriorConstant
         
+        if isFourPointRelative is not None:
+            self.isFourPointRelative = isFourPointRelative
+        
         if gaussianParams:
             self.gaussianParams = gaussianParams
         
@@ -336,7 +341,20 @@ class DAQStageProgram():
 
         if self.mode == StageProgramMode.FourPoint:
 
-            val = Vertex2D.bilerp(self.quadVertex[0], self.quadVertex[1], self.quadVertex[2], self.quadVertex[3], np.array([x, y], np.float32), self.exterior, self.exteriorConstant)
+            currentPosition = np.array([x, y], np.float32)
+            if self.isFourPointRelative:
+                currentPosition = currentPosition - self.startRecordPosition
+                self.quadVertex[0].point
+            
+            val = Vertex2D.bilerp(
+                self.quadVertex[0], 
+                self.quadVertex[1], 
+                self.quadVertex[2], 
+                self.quadVertex[3], 
+                currentPosition, 
+                self.exterior, 
+                self.exteriorConstant
+            )
 
         
         elif self.mode == StageProgramMode.Gaussian:
@@ -374,10 +392,12 @@ class DAQStageProgram():
             np.ndarray: RGB image of the plot
         """
         stageRange = [160, 160]
+
+        isRelativeToStart = self.isFourPointRelative or self.isGaussianRelative
         
         # Allocate value map
         valMapShape = [stageRange[0] + 1, stageRange[1] + 1, 1]
-        if self.isGaussianRelative:
+        if isRelativeToStart:
             valMapShape = [stageRange[0]*2 + 1, stageRange[1]*2 + 1, 1]
         
         valMap = np.zeros(valMapShape)
@@ -386,13 +406,13 @@ class DAQStageProgram():
         for j in range(valMap.shape[0]):
 
             y = j
-            if self.isGaussianRelative:
+            if isRelativeToStart:
                 y = y - stageRange[0]
                 
             for i in range(valMap.shape[1]):
 
                 x = i
-                if self.isGaussianRelative:
+                if isRelativeToStart:
                     x = x - stageRange[1]
 
                 valMap[j, i] = self.getValue(x, y)
@@ -403,7 +423,7 @@ class DAQStageProgram():
         
         # Plot map
         extent = None
-        if self.isGaussianRelative:
+        if isRelativeToStart:
             extent = (-stageRange[0], stageRange[0], stageRange[1], -stageRange[1])
 
         im = plt.imshow(valMap, cmap= 'magma', extent= extent)
@@ -424,11 +444,11 @@ class DAQStageProgram():
         elif self.mode == StageProgramMode.Gaussian:
             drawPointWithAnnotation([self.gaussianParams.x_mean, self.gaussianParams.y_mean], 'r', 'Mean')
         
-        if self.isGaussianRelative:
+        if isRelativeToStart:
             drawPointWithAnnotation([0, 0], 'r', 'Start Pos')
 
         # Set plot limits and labels
-        if self.isGaussianRelative:
+        if isRelativeToStart:
             plt.xlim(-stageRange[0], stageRange[0])
             plt.ylim(-stageRange[1], stageRange[1])
 

--- a/glowtracker/DAQ_control.py
+++ b/glowtracker/DAQ_control.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 import LabJackPython
 import u3
 import re
-from enum import StrEnum
+from enum import Enum
 from collections import OrderedDict
 from copy import deepcopy
 from typing import List
@@ -14,18 +14,18 @@ from matplotlib.backends.backend_agg import FigureCanvasAgg
 from dataclasses import dataclass
 
 
-class LEDsMode(StrEnum):
+class LEDsMode(Enum):
     Off = 'Off'
     Sequencer = 'Sequencer'
     StageProgram = 'StageProgram'
 
 
-class SequencerMode(StrEnum):
+class SequencerMode(Enum):
     Frame = 'Frame'
     Time = 'Time'
 
 
-class StageProgramMode(StrEnum):
+class StageProgramMode(Enum):
     FourPoint = 'FourPoint'
     Gaussian = 'Gaussian'
 

--- a/glowtracker/DAQ_control.py
+++ b/glowtracker/DAQ_control.py
@@ -268,9 +268,18 @@ class DAQStageProgram():
         self.exterior = Exterior.Zero
         self.exteriorConstant: float = 0
         self.gaussianParams = GaussianParams()
+        self.isGaussianRelative = False
     
     
-    def update(self, mode: StageProgramMode = None, quadVertex: List[Vertex2D] = None, exterior: Exterior = None, exteriorConstant: float = None, gaussianParams: GaussianParams = None) -> None:
+    def update(
+            self, 
+            mode: StageProgramMode | None = None, 
+            quadVertex: List[Vertex2D] | None = None, 
+            exterior: Exterior | None = None, 
+            exteriorConstant: float | None = None, 
+            gaussianParams: GaussianParams | None = None, 
+            isGaussianRelative: bool | None = None
+        ) -> None:
         """Parse variables and process them.
 
         Args:
@@ -304,6 +313,9 @@ class DAQStageProgram():
         
         if gaussianParams:
             self.gaussianParams = gaussianParams
+        
+        if isGaussianRelative:
+            self.isGaussianRelative = isGaussianRelative
     
     
     def getValue(self, x: float, y: float) -> float:

--- a/glowtracker/DAQ_control.py
+++ b/glowtracker/DAQ_control.py
@@ -5,6 +5,13 @@ import re
 from enum import StrEnum
 from collections import OrderedDict
 from copy import deepcopy
+from typing import List
+from Microscope_macros import Vertex2D, Exterior
+import numpy as np
+import math
+from matplotlib import pyplot as plt
+from matplotlib.backends.backend_agg import FigureCanvasAgg
+
 
 class LEDsMode(StrEnum):
     Off = 'Off'
@@ -63,13 +70,8 @@ class DAQControl():
         self.ledsMode: LEDsMode = LEDsMode.Off
         self.sequencerMode: SequencerMode = SequencerMode.Frame
         self.stageProgramMode: StageProgramMode = StageProgramMode.FourPoint
+        self.daqStageProgram: DAQStageProgram = DAQStageProgram()
 
-        # LedsStageProgramWidget ?
-        #   We want to evalute this
-        #       val = Vertex2D.bilerp(self.quadVertex[0], self.quadVertex[1], self.quadVertex[2], self.quadVertex[3], np.array([x, y], np.float32), self.exterior, self.exteriorConstant)
-        #       Or even
-        #       val = Gaussian distance or something
-        #
 
     def close(self):
         # Check if Windows then call LabJackPython.Close(), else call self.daq.close()
@@ -141,8 +143,21 @@ class DAQControl():
             raise ValueError(f"Failed to parse LED script text: {e}")
     
 
-    def triggerCommand(self, frameNum: int = 0, frameTime: float = 0) -> None:
+    def update(self, frameNum: int = 0, frameTime: float = 0, stagePosition: List[float] = []) -> None:
+        if self.ledsMode == LEDsMode.Off:
+            return
         
+        elif self.ledsMode == LEDsMode.Sequencer:
+            self.updateSequencer(frameNum= frameNum, frameTime= frameTime)
+        
+        elif self.ledsMode == LEDsMode.StageProgram:
+            self.updateStageProgram(stagePosition)
+
+
+    def updateSequencer(self, frameNum: int = 0, frameTime: float = 0) -> None:
+
+        # Seperate this into two cases, one for each LEDsMode
+        #   Also need stage position input
         if len(self.ledsSequnceDictRunning) == 0 or not self.ledsMode == LEDsMode.Sequencer:
             return
 
@@ -189,6 +204,13 @@ class DAQControl():
                     self._executeCommand(frameCommand)
 
 
+    def updateStageProgram(self, stagePosition: List[float]) -> None:
+        #   We want to evalute this
+        vol = self.daqStageProgram.getValue(stagePosition[0], stagePosition[1])
+        
+        self._executeCommand(frameCommand= ['on', vol])
+    
+
     def _executeCommand(self, frameCommand: list) -> None:
         
         command: list = frameCommand[0]
@@ -219,3 +241,103 @@ class DAQControl():
             dac0Val = self.daq.voltageToDACBits(volts= 0, dacNumber= 0, is16Bits= False)
             dac0Command = u3.DAC0_8(dac0Val)
             self.daq.getFeedback(dac0Command)
+
+
+class DAQStageProgram():
+
+    def __init__(self):
+        self.quadVertex: List[Vertex2D] = []
+        self.exterior = Exterior.Zero
+        self.exteriorConstant: float = 0
+    
+    
+    def update(self, quadVertex: List[Vertex2D], exterior: Exterior, exteriorConstant: float) -> None:
+        """Parse variables and sort vertices in anti-clockwise order.
+
+        Args:
+            quadVertex (List[Vertex2D]): _description_
+            exterior (Exterior): _description_
+            exteriorConstant (float): _description_
+        """
+
+        self.quadVertex = quadVertex
+        self.exterior = exterior
+        self.exteriorConstant = exteriorConstant
+
+        center = np.zeros([2], np.float32)
+        for vert in quadVertex:
+            center = center + vert.point
+        center = center / 4
+
+        # Sort points in anti-clockwise order starting from btmLeft: btmLeft, btmRight, topRight, topRight
+        self.quadVertex.sort(key= lambda vertex: math.atan2(vertex.point[1] - center[1], vertex.point[0] - center[0]))
+    
+    
+    def getValue(self, x: float, y: float) -> float:
+        """Get an interpolated signal value at a given stage position.
+
+        Args:
+            x (float): stage x-position
+            y (float): stage y-position
+
+        Returns:
+            float: bilinear-interpolated voltage
+        """
+
+        val = Vertex2D.bilerp(self.quadVertex[0], self.quadVertex[1], self.quadVertex[2], self.quadVertex[3], np.array([x, y], np.float32), self.exterior, self.exteriorConstant)
+
+        # Clamp between 0, 5 vol
+        val = min(max(0, val), 5)
+
+        return val
+
+
+    def generateValueMapPlot(self)-> np.ndarray:
+        """Generate a heat-map plot of possible values on the stage area.
+
+        Returns:
+            np.ndarray: RGB image of the plot
+        """
+        
+        # Compute value map
+        valMap = np.zeros([160 + 1, 160 + 1, 1], np.float32)
+        for y in range(valMap.shape[0]):
+            for x in range(valMap.shape[1]):
+                valMap[y, x] = self.getValue(x, y)
+            
+        
+        # Create the plot
+        fig = plt.figure(figsize=(6, 6))
+        
+        # Plot map
+        im = plt.imshow(valMap, cmap= 'magma')
+        plt.colorbar(im)
+        
+        # Plot 4 points
+        def drawPointWithAnnotation(point: List[float], color: str, name: str) -> None:
+            plt.scatter(point[0], point[1], c= color)
+            plt.annotate(name, (point[0], point[1]), textcoords= 'offset points', xytext= (10,10), ha= 'center', fontsize= 12, color= 'green')
+        
+        drawPointWithAnnotation(self.quadVertex[0].point, 'r', self.quadVertex[0].name)
+        drawPointWithAnnotation(self.quadVertex[1].point, 'r', self.quadVertex[1].name)
+        drawPointWithAnnotation(self.quadVertex[2].point, 'r', self.quadVertex[2].name)
+        drawPointWithAnnotation(self.quadVertex[3].point, 'r', self.quadVertex[3].name)
+
+        # Set plot limits and labels
+        plt.xlim(0, 160)
+        plt.ylim(0, 160)
+        plt.xlabel('X')
+        plt.ylabel('Y')
+
+        # Add grid and legend
+        plt.grid(True)
+
+        # Render the plot to a numpy array
+        canvas = FigureCanvasAgg(fig)
+        canvas.draw()
+        width, height = fig.get_size_inches() * fig.get_dpi()
+        imageArr = np.frombuffer(canvas.tostring_argb(), dtype='uint8').reshape(int(height), int(width), 4)
+        # Remove alpha channel at the front
+        imageArr = imageArr[:,:,1:4]
+
+        return imageArr

--- a/glowtracker/DAQ_control.py
+++ b/glowtracker/DAQ_control.py
@@ -393,7 +393,8 @@ class DAQStageProgram():
         """
         stageRange = [160, 160]
 
-        isRelativeToStart = self.isFourPointRelative or self.isGaussianRelative
+        isRelativeToStart = (self.mode == StageProgramMode.FourPoint and self.isFourPointRelative) \
+                            or (self.mode == StageProgramMode.Gaussian and self.isGaussianRelative)
         
         # Allocate value map
         valMapShape = [stageRange[0] + 1, stageRange[1] + 1, 1]

--- a/glowtracker/DAQ_control.py
+++ b/glowtracker/DAQ_control.py
@@ -2,6 +2,14 @@ from __future__ import annotations
 import LabJackPython
 import u3
 import re
+from enum import StrEnum
+from collections import OrderedDict
+from copy import deepcopy
+
+class TriggerUpdateMode(StrEnum):
+    Frame = 'Frame'
+    Time = 'Time'
+
 
 class DAQControl():
 
@@ -41,8 +49,10 @@ class DAQControl():
 
     def __init__(self):
         self.daq: u3.U3 | None = None
-        self.ledsSequnceDict : dict | None = None
+        self.ledsSequnceDict : OrderedDict = OrderedDict()
+        self.ledsSequnceDictRunning : OrderedDict = OrderedDict()
         self.isEnable: bool = False
+        self.mode: TriggerUpdateMode = TriggerUpdateMode.Frame
 
     
     def close(self):
@@ -51,9 +61,23 @@ class DAQControl():
         self.daq = None
 
     
+    def start(self):
+        """Reset internal command dict to original to prepare for running.
+        """
+        self.ledsSequnceDictRunning = deepcopy(self.ledsSequnceDict)
+    
+    
     def reset(self):
+        """Set DAQ values to factory default. Should be call after finished executing a command list.
+        """
         # Set to factory default
-        self.daq.setDefaults()
+        self.daq.setDefaults(SetToFactoryDefaults= True)
+        # Manually set DAC0 to 0 (off)
+        dac0Val = self.daq.voltageToDACBits(volts= 0, dacNumber= 0, is16Bits= False)
+        dac0Command = u3.DAC0_8(dac0Val)
+        self.daq.getFeedback(dac0Command)
+        # Clean running command queue
+        self.ledsSequnceDictRunning.clear()
 
         
     def parseTextScript(self, text: str) -> None:
@@ -69,22 +93,88 @@ class DAQControl():
             preprocessdText = "{\n" + ",\n".join(lines) + "\n}"
             
             # Parse the text to be a dict object. Highlight keywords "on", "off"
-            self.ledsSequnceDict = eval(preprocessdText, globals= {"on": "on", "off": "off"})
-        
+            processedDict = eval(preprocessdText, globals= {
+                "on": "on", 
+                "off": "off", 
+                "mode": "mode",
+                "frame": "frame",
+                "time": "time"
+            })
+
+            # Check if empty
+            if len(processedDict) == 0:
+                self.ledsSequnceDict.clear()
+                return
+
+            # Get running mode
+            mode = processedDict.pop('mode')[0]
+            
+            # Sort and convert to OrderedDict
+            self.ledsSequnceDict = OrderedDict( {key:val for key, val in sorted(processedDict.items(), key= lambda x: x[0])} )
+
+            if mode == 'frame':
+                self.mode = TriggerUpdateMode.Frame
+
+            elif mode == 'time':
+                self.mode = TriggerUpdateMode.Time
+                
+            else:
+                raise ValueError(f"Failed to parse LED script text: Invalid 'mode' argument. Options are ['frame', 'time']")
+
         except Exception as e:
-            raise ValueError(f"Failed to parse LED script text: {e}") from None
+            raise ValueError(f"Failed to parse LED script text: {e}")
     
 
-    def triggerCommand(self, frameNum: int) -> None:
+    def triggerCommand(self, frameNum: int = 0, frameTime: float = 0) -> None:
         
-        if self.ledsSequnceDict is None or not self.isEnable:
-            return
-        
-        frameCommand = self.ledsSequnceDict.get(frameNum)
-
-        if frameCommand is None:
+        if len(self.ledsSequnceDictRunning) == 0 or not self.isEnable:
             return
 
+        if self.mode == TriggerUpdateMode.Frame:
+        
+            # Get the exact frame command
+            frameCommand = self.ledsSequnceDictRunning.pop(frameNum, default= None)
+
+            if frameCommand is not None:
+                print(f"Frame {frameNum}:")
+                self._executeCommand(frameCommand)
+        
+        elif self.mode == TriggerUpdateMode.Time:
+            
+            # Get the first (lowest frame time) command in queue
+            commandFrameTime = next(iter(self.ledsSequnceDictRunning))
+
+            if frameTime >= commandFrameTime:
+
+                # Pop the command
+                # Get all the commands with time that are lower than the frame time
+                commands = []
+                while commandFrameTime <= frameTime and len(self.ledsSequnceDictRunning) > 0:
+
+                    # Pop first item (lowest frame time)
+                    commandFrameTime, frameCommand = self.ledsSequnceDictRunning.popitem(last= False)
+                    commands.append([commandFrameTime, frameCommand])
+
+                    # If the command queue is now empty then stop
+                    if len(self.ledsSequnceDictRunning) == 0:
+                        break
+                    
+                    # Get the next one
+                    commandFrameTime = next(iter(self.ledsSequnceDictRunning))
+
+                    # If the next commandFrameTime is already higher then break
+                    if commandFrameTime > frameTime:
+                        break
+                
+                if len(commands) > 0:
+                    # Execute the last command (closest to the frame time)
+                    commandFrameTime, frameCommand = commands[-1]
+                    print(f"Time {frameTime:.3f} sec:")
+                    self._executeCommand(frameCommand)
+
+
+    def _executeCommand(self, frameCommand: list) -> None:
+        
         command: list = frameCommand[0]
 
         if command == 'on':
@@ -97,7 +187,7 @@ class DAQControl():
             # Clip to 0, 4.95
             vol = max( min( vol, 4.95 ), 0 )
 
-            print(f"Turn on the light! {vol}")
+            print(f"Light on {vol} vol")
 
             # Send command to DAQ at DAC0
             dac0Val = self.daq.voltageToDACBits(volts= vol, dacNumber= 0, is16Bits= False)
@@ -107,10 +197,9 @@ class DAQControl():
         
         elif command == 'off':
             
-            print(f"Turn off the light!")
+            print(f"Light off")
 
             # Send command to DAQ at DAC0
             dac0Val = self.daq.voltageToDACBits(volts= 0, dacNumber= 0, is16Bits= False)
             dac0Command = u3.DAC0_8(dac0Val)
             self.daq.getFeedback(dac0Command)
-        

--- a/glowtracker/GlowTracker.py
+++ b/glowtracker/GlowTracker.py
@@ -2081,7 +2081,7 @@ class RecordButton(ImageAcquisitionButton):
 
         # Prep DAQ control
         if self.app.daqControl.isConnected() and self.app.daqControl.ledsMode != LEDsMode.Off:
-            self.app.daqControl.start()
+            self.app.daqControl.start( np.array(self.app.coords[:2]) )
 
         # Setup image acquisition thread parameters
         self.initRecordingParams()

--- a/glowtracker/GlowTracker.py
+++ b/glowtracker/GlowTracker.py
@@ -1219,8 +1219,7 @@ class LedsStageProgramWidget(BoxLayout):
         # Plot 4 points
         def drawPointWithAnnotation(point: List[float], color: str, name: str) -> None:
             plt.scatter(point[0], point[1], c= color)
-            plt.annotate(name, (point[0], point[1]), textcoords= 'offset points', xytext= (10,10), \
-                            ha= 'center', fontsize= 12, color= 'black')
+            plt.annotate(name, (point[0], point[1]), textcoords= 'offset points', xytext= (10,10), ha= 'center', fontsize= 12, color= 'green')
         
         drawPointWithAnnotation(vertices[0].point, 'r', vertices[0].name)
         drawPointWithAnnotation(vertices[1].point, 'r', vertices[1].name)

--- a/glowtracker/GlowTracker.py
+++ b/glowtracker/GlowTracker.py
@@ -71,6 +71,7 @@ import shutil
 from pyparsing import ParseException
 import matplotlib.pyplot as plt
 from dataclasses import dataclass
+import re
 
 # 
 # Own classes
@@ -450,7 +451,7 @@ class MacroScriptWidgetPopup(DragBehavior, Popup):
         Returns:
             has_been_handled(bool): Flag to indicate if the touch event has been handled or not to stop propagation.
         """
-        discardRegion: CodeInput = self.content.ids.macroscripttext
+        discardRegion: CodeInput = self.content.ids.scripttext
         
         if discardRegion.collide_point(*touch.pos):
             return discardRegion.on_touch_down(touch)
@@ -568,7 +569,7 @@ class MacroScriptWidget(BoxLayout):
         """Open a popup to load the macro script.
         """
         
-        loadWidget = LoadMacroScriptWidget(load= self._loadScriptWidgetCallback)
+        loadWidget = LoadScriptWidget(load= self._loadScriptWidgetCallback)
         self._popup = Popup(title= "Load macro script file", content= loadWidget,
             size_hint= (0.9, 0.9), auto_dismiss= False)
 
@@ -578,7 +579,7 @@ class MacroScriptWidget(BoxLayout):
     
     def _loadScriptWidgetCallback(self, selection: list[str]):
         """Load the macro script from a list of given file path. Will choose only the first file.
-        Used for handler of LoadMacroScriptWidget.
+        Used for handler of LoadScriptWidget.
 
         Args:
             selection (list[str]): list of script file path
@@ -617,7 +618,7 @@ class MacroScriptWidget(BoxLayout):
         
         # Set display text
         self.ids.macroscriptfile.text = self.macroScriptFile
-        self.ids.macroscripttext.text = self.macroScript
+        self.ids.scripttext.text = self.macroScript
 
         # Set as recent script
         self.app.config.set('MacroScript', 'recentscript', self.macroScriptFile)
@@ -628,7 +629,7 @@ class MacroScriptWidget(BoxLayout):
         """Save the current macro script into the same file (overwrite if exists).
         """
         file_path = self.ids.macroscriptfile.text
-        script = self.ids.macroscripttext.text
+        script = self.ids.scripttext.text
 
         try:
             # Convert to absolute path if it's a relative path
@@ -661,7 +662,7 @@ class MacroScriptWidget(BoxLayout):
 
         print(f'Running the macro script {self.macroScriptFile}.')
         try:
-            self.macroScriptExecutor.executeScript(self.ids.macroscripttext.text, self.finishedMacroScript)
+            self.macroScriptExecutor.executeScript(self.ids.scripttext.text, self.finishedMacroScript)
 
             # Disable the run button
             self.ids.runbutton.disabled = True
@@ -686,7 +687,7 @@ class MacroScriptWidget(BoxLayout):
         self.macroScriptExecutor.stop()
 
 
-class LoadMacroScriptWidget(BoxLayout):
+class LoadScriptWidget(BoxLayout):
     """Camera settings loading widget
     """
     load = ObjectProperty(None)
@@ -955,7 +956,7 @@ class DepthOfFieldCalibration(BoxLayout):
 
 
 class LedsControlWidget(BoxLayout):
-    """MacroScriptExecutor widget that holds the parser and the function handler
+    """Widget that holds the parser and the function handler
     """
     closeCallback = ObjectProperty(None)
 
@@ -968,32 +969,28 @@ class LedsControlWidget(BoxLayout):
         self.app: GlowTrackerApp = kwargs.pop('app', None)
         
         super(LedsControlWidget, self).__init__(**kwargs)
-
+        
         # Attributes
-        self.macroScriptFile: str = self.ids.macroscriptfile.text
-        self.macroScript: str = ''
+        self.ledsScriptFile: str = self.ids.ledsscriptfile.text
+        self.ledsScript: str = ''
+        self.ledsSequnceDict: dict = dict()
         self._popup: Popup = None
 
         # Initialize MacroScriptExecutor
         self.stage = self.app.stage
         self.camera = self.app.camera
         self.imageAcquisitionManager: ImageAcquisitionManager = self.app.root.ids.middlecolumn.ids.runtimecontrols.imageacquisitionmanager
-        self.recordButton: RecordButton = self.imageAcquisitionManager.recordbutton
-        position_unit = 'mm'
-
-        # Register appropriate function handler
-        
 
         # Load the recent script
-        if self.macroScriptFile != '':
-            self.loadMacroScript(self.macroScriptFile)
+        if self.ledsScriptFile != '':
+            self.loadScript(self.ledsScriptFile)
 
 
     def openLoadLedsControlWidget(self):
-        """Open a popup to load the macro script.
+        """Open a popup to load the script.
         """
         
-        loadWidget = LoadMacroScriptWidget(load= self._loadScriptWidgetCallback)
+        loadWidget = LoadScriptWidget(load= self._loadScriptWidgetCallback)
         self._popup = Popup(title= "Load macro script file", content= loadWidget,
             size_hint= (0.9, 0.9), auto_dismiss= False)
 
@@ -1003,7 +1000,7 @@ class LedsControlWidget(BoxLayout):
     
     def _loadScriptWidgetCallback(self, selection: list[str]):
         """Load the macro script from a list of given file path. Will choose only the first file.
-        Used for handler of LoadMacroScriptWidget.
+        Used for handler of LoadScriptWidget.
 
         Args:
             selection (list[str]): list of script file path
@@ -1015,45 +1012,63 @@ class LedsControlWidget(BoxLayout):
         if len(selection) == 0:
             return
         
-        self.loadMacroScript(selection[0])
+        self.loadScript(selection[0])
     
     
-    def loadMacroScript(self, filePath: str):
-        """Load the macro script from a given file path.
+    def loadScript(self, filePath: str):
+        """Load the script from a given file path.
 
         Args:
             filePath (str): _description_
         """
         # Get the absolute file path
-        self.macroScriptFile = os.path.abspath(filePath)
+        self.ledsScriptFile = os.path.abspath(filePath)
         
         # Load the script text
-        print(f'Loading the macro script {self.macroScriptFile}')
+        print(f'Loading the LEDs control script {self.ledsScriptFile}')
 
         try:
-            with open(self.macroScriptFile, 'r') as file:
-                self.macroScript = file.read()
+            with open(self.ledsScriptFile, 'r') as file:
+                self.ledsScript = file.read()
 
         except FileNotFoundError:
-            print(f'The file {self.macroScriptFile} was not found.')
+            print(f'The file {self.ledsScriptFile} was not found.')
 
         except IOError:
-            print(f'An error occurred while reading the file {self.macroScriptFile}.')
+            print(f'An error occurred while reading the file {self.ledsScriptFile}.')
         
         # Set display text
-        self.ids.macroscriptfile.text = self.macroScriptFile
-        self.ids.macroscripttext.text = self.macroScript
+        self.ids.ledsscriptfile.text = self.ledsScriptFile
+        self.ids.scripttext.text = self.ledsScript
 
         # Set as recent script
-        self.app.config.set('MacroScript', 'recentscript', self.macroScriptFile)
+        self.app.config.set('LedsControl', 'recentscript', self.ledsScriptFile)
         self.app.config.write()
-    
+
+        # Parse text to dict
+        try:
+            
+            # Remove empty lines and surrounding whitespace
+            lines = [line.strip() for line in self.ledsScript.splitlines() if line.strip()]
+
+            # Remove trailing commas from each line
+            lines = [re.sub(r',$', '', line) for line in lines]
+
+            # Wrap into a dict literal
+            preprocessdText = "{\n" + ",\n".join(lines) + "\n}"
+            
+            # Parse the text to be a dict object. Highlight keywords "on", "off"
+            self.ledsSequnceDict = eval(preprocessdText, globals= {"on": "on", "off": "off"})
+            
+        except Exception as e:
+            raise ValueError(f"Failed to parse input text: {e}") from None
+        
 
     def saveScript(self):
         """Save the current macro script into the same file (overwrite if exists).
         """
-        file_path = self.ids.macroscriptfile.text
-        script = self.ids.macroscripttext.text
+        file_path = self.ids.ledsscriptfile.text
+        script = self.ids.scripttext.text
 
         try:
             # Convert to absolute path if it's a relative path
@@ -1069,7 +1084,7 @@ class LedsControlWidget(BoxLayout):
                 file.write(script)
 
             # Set as recent script
-            self.app.config.set('MacroScript', 'recentscript', self.ids.macroscriptfile.text)
+            self.app.config.set('LedsControl', 'recentscript', self.ids.ledsscriptfile.text)
 
             print(f"Saved the script {file_path}")
 
@@ -3665,6 +3680,10 @@ class GlowTrackerApp(App):
         })
 
         config.setdefaults('MacroScript', {
+            'recentscript': ''
+        })
+
+        config.setdefaults('LedsControl', {
             'recentscript': ''
         })
 

--- a/glowtracker/GlowTracker.py
+++ b/glowtracker/GlowTracker.py
@@ -403,27 +403,31 @@ class RightColumn(BoxLayout):
             self._popup.open()
         
         else:
-            self._popup = WarningPopup(title="Calibration", text='Autocalibration requires a stage and a camera. Connect a stage or use a calibration slide.',
-                            size_hint=(0.5, 0.25))
+            self._popup = WarningPopup(title="Calibration", text='Autocalibration requires a stage and a camera. Connect a stage or use a calibration slide.', size_hint=(0.5, 0.25), closeTime= 5)
             self._popup.open()
 
     
     def open_leds(self):
         """Open the LEDs Control Sequence widget popup.
         """
-        
-        # Disabled interaction with preview image widget
-        self.app.root.ids.middlecolumn.ids.scalableimage.disabled = True
-        # Unbind keyboard events
-        self.app.unbind_keys()
+        if self.app.daqControl is not None:
 
-        # Create LedsControlTabPanel Widget
-        ledsControlTabPanelHolder = LedsControlTabPanelHolder()
-        ledsControlTabPanelHolder.setCloseCallback(closeCallback= self.dismiss_popup)
-        # Launch the widget inside a popup window
-        self._popup = Popup(title= '', separator_height= 0, content= ledsControlTabPanelHolder, size_hint= (0.7, 0.7))
+            # Disabled interaction with preview image widget
+            self.app.root.ids.middlecolumn.ids.scalableimage.disabled = True
+            # Unbind keyboard events
+            self.app.unbind_keys()
 
-        self._popup.open()
+            # Create LedsControlTabPanel Widget
+            ledsControlTabPanelHolder = LedsControlTabPanelHolder()
+            ledsControlTabPanelHolder.setCloseCallback(closeCallback= self.dismiss_popup)
+            
+            # Launch the widget inside a popup window
+            self._popup = Popup(title= '', separator_height= 0, content= ledsControlTabPanelHolder, size_hint= (0.7, 0.7))
+            self._popup.open()
+
+        else:
+            self._popup = WarningPopup(title="LEDs", text='LEDs Control Panel requires a connection to a DAQ device.', size_hint=(0.5, 0.25), closeTime= 5)
+            self._popup.open()
 
 
 class MacroScriptWidgetPopup(DragBehavior, Popup):
@@ -4444,8 +4448,8 @@ class GlowTrackerApp(App):
                 imageNormalDir = 1 if imageNormalDir == '+Z' else -1
                 rotation = self.config.getfloat('Camera', 'rotation')
 
-                self.imageToStageMat, self.imageToStageRotMat = macro.CameraAndStageCalibrator.genImageToStageMatrix(pixelsize, imageNormalDir, rotation)
-        
+                self.imageToStageMat, self.imageToStageRotMat = macro.CameraAndStageCalibrator.genImageToStageMatrix(rotation= rotation, imageNormalDir= imageNormalDir, pixelSize= pixelsize)
+
         elif section == 'DualColor':
             
             if key == 'dualcolormode':

--- a/glowtracker/GlowTracker.py
+++ b/glowtracker/GlowTracker.py
@@ -408,13 +408,11 @@ class RightColumn(BoxLayout):
         # Unbind keyboard events
         self.app.unbind_keys()
 
-        # Create LedsControlWidget Draggable Popup
-        widget = LedsControlWidget(app = self.app)
-        widget.closeCallback = self.dismiss_popup
-        self._popup = MacroScriptWidgetPopup(title= "LEDs Control Sequence", content= widget, size_hint= (0.5, 0.7), auto_dismiss = False)
-        self._popup.closeCallback = self.dismiss_popup
-
-        # Open the widget
+        # Create LedsControlTabPanel Widget
+        ledsControlTabPanel = LedsControlTabPanel()
+        ledsControlTabPanel.setCloseCallback(closeCallback= self.dismiss_popup)
+        # Launch the widget inside a popup window
+        self._popup = Popup(title= '', separator_height= 0, content= ledsControlTabPanel, size_hint= (0.9, 0.75))
         self._popup.open()
 
 
@@ -956,34 +954,59 @@ class DepthOfFieldCalibration(BoxLayout):
         liveViewButton.state = prevLiveViewButtonState
 
 
+class LedsControlTabPanel(TabbedPanel):
+    """Calibration widget that holds CameraAndStageCalibration, DualColorCalibration, and DepthOfFieldCalibration
+    """    
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.ids.ledssequencer.init()
+        self.ids.ledsstageprogram.init()
+    
+
+    def setCloseCallback(self, closeCallback: callable) -> None:
+        """API setting close callback event for children' tab.
+
+        Args:
+            closeCallback (callable): the closing callback event.
+        """        
+        self.closeCallback = closeCallback
+        self.ids.ledssequencer.setCloseCallback( closeCallback )
+        self.ids.ledsstageprogram.setCloseCallback( closeCallback )
+
+
 class LedsControlWidget(BoxLayout):
     """Widget that holds the parser and the function handler
     """
     closeCallback = ObjectProperty(None)
 
     def __init__(self, **kwargs):
-
-        # Intercept GlowTrackerApp reference object.
-        #   There is a bug that if we call to get reference directly by App().get_running_app(),
-        #   we would get a new GlowTrackerApp object that has different object id, and no config, root, etc. 
-        #   like a completely new object.
-        self.app: GlowTrackerApp = kwargs.pop('app', None)
-        
         super(LedsControlWidget, self).__init__(**kwargs)
-        
-        # Attributes
-        self.ledsScriptFile: str = self.ids.ledsscriptfile.text
-        self.ledsScript: str = ''
-        self._popup: Popup = None
 
+
+    def init(self):
+        
         # Initialize MacroScriptExecutor
+        self.app: GlowTrackerApp = App.get_running_app()
         self.stage = self.app.stage
         self.camera = self.app.camera
         self.imageAcquisitionManager: ImageAcquisitionManager = self.app.root.ids.middlecolumn.ids.runtimecontrols.imageacquisitionmanager
 
+        self.ledsScript: str = ''
+        self._popup: Popup = None
+        self.ledsScriptFile: str = self.ids.ledsscriptfile.text
         # Load the recent script
         if self.ledsScriptFile != '':
             self.loadScript(self.ledsScriptFile)
+
+    
+    def setCloseCallback( self, closeCallback: callable ) -> None:
+        """Set widget closing callback.
+
+        Args:
+            closeCallback (callable): the closing callback.
+        """        
+        self.closeCallback = closeCallback
 
 
     def openLoadLedsControlWidget(self):
@@ -1081,24 +1104,73 @@ class LedsControlWidget(BoxLayout):
             print(f"Error saving LED script: {e}")
     
 
-class LedsEnableSwitch(Switch):
+class LedsStageProgramWidget(BoxLayout):
+    """Widget that holds the parser and the function handler
+    """
+    closeCallback = ObjectProperty(None)
 
     def __init__(self, **kwargs):
-        super(LedsEnableSwitch, self).__init__(**kwargs)
+        super(LedsStageProgramWidget, self).__init__(**kwargs)
+
+
+    def init(self):
+        
+        # Initialize MacroScriptExecutor
         self.app: GlowTrackerApp = App.get_running_app()
-        self.active = self.app.config.getboolean('LedsControl', 'isenable')
+        self.stage = self.app.stage
+        self.camera = self.app.camera
+        self.imageAcquisitionManager: ImageAcquisitionManager = self.app.root.ids.middlecolumn.ids.runtimecontrols.imageacquisitionmanager
+        self._popup: Popup = None
+
+    
+    def setCloseCallback( self, closeCallback: callable ) -> None:
+        """Set widget closing callback.
+
+        Args:
+            closeCallback (callable): the closing callback.
+        """        
+        self.closeCallback = closeCallback
+    
+
+class LedsSequencerEnableSwitch(Switch):
+
+    def __init__(self, **kwargs):
+        super(LedsSequencerEnableSwitch, self).__init__(**kwargs)
+        self.app: GlowTrackerApp = App.get_running_app()
+        self.active = self.app.config.getboolean('LedsControl', 'isenablesequencer')
     
 
     def on_touch_up(self, touch): 
-        """On switch touch up callback. Update the config value 'isenable',
+        """On switch touch up callback. Update the config value 'isenablesequencer',
 
         Args:
             touch (Touch): touch input data.
         """
-        super(LedsEnableSwitch, self).on_touch_up(touch)
+        super(LedsSequencerEnableSwitch, self).on_touch_up(touch)
 
         self.app.daqControl.isEnable = self.active
-        self.app.config.set('LedsControl', 'isenable', int(self.active))
+        self.app.config.set('LedsControl', 'isenablesequencer', int(self.active))
+        self.app.config.write()
+
+
+class LedsStageProgramEnableSwitch(Switch):
+
+    def __init__(self, **kwargs):
+        super(LedsStageProgramEnableSwitch, self).__init__(**kwargs)
+        self.app: GlowTrackerApp = App.get_running_app()
+        self.active = self.app.config.getboolean('LedsControl', 'isenablestageprogram')
+    
+
+    def on_touch_up(self, touch): 
+        """On switch touch up callback. Update the config value 'isenablestageprogram',
+
+        Args:
+            touch (Touch): touch input data.
+        """
+        super(LedsStageProgramEnableSwitch, self).on_touch_up(touch)
+
+        self.app.daqControl.isEnable = self.active
+        self.app.config.set('LedsControl', 'isenablestageprogram', int(self.active))
         self.app.config.write()
 
 
@@ -3766,7 +3838,8 @@ class GlowTrackerApp(App):
 
         config.setdefaults('LedsControl', {
             'recentscript': '',
-            'isenable': 'false'
+            'isenablesequencer': 'false',
+            'isenablestageprogram': 'false'
         })
 
         config.setdefaults('Developer', {
@@ -4168,12 +4241,12 @@ class GlowTrackerApp(App):
 
         elif section == 'LedsControl':
 
-            if key == 'isenable':
-                updateOverlayFlag = True
+            if key == 'isenablesequencer':
+                self.daqControl.isEnable = bool(int(value))
 
-                # Also update the TrackingOverlay Quick Button
-                isenable = bool(int(value))
-                self.daqControl.isEnable = isenable
+
+            if key == 'isenablestageprogram':
+                self.daqControl.isEnable = bool(int(value))
 
 
         elif section == 'Developer':

--- a/glowtracker/GlowTracker.py
+++ b/glowtracker/GlowTracker.py
@@ -71,7 +71,6 @@ import platformdirs
 import shutil
 from pyparsing import ParseException
 import matplotlib.pyplot as plt
-from matplotlib.backends.backend_agg import FigureCanvasAgg
 from dataclasses import dataclass
 
 # 
@@ -1165,8 +1164,6 @@ class LedsStageProgramWidget(BoxLayout):
         self.imageAcquisitionManager: ImageAcquisitionManager = self.app.root.ids.middlecolumn.ids.runtimecontrols.imageacquisitionmanager
         self.exterior = macro.Exterior.Zero
         self._popup: Popup = None
-        self.quadVertex: List[Vertex2D] = []
-        self.exteriorConstant: float = 0
         self.updateLedStageProgram()
 
     
@@ -1182,11 +1179,7 @@ class LedsStageProgramWidget(BoxLayout):
     def updateExteriorChoice(self) ->None:
 
         # Parse choice text to enum
-        if self.exteriorSpinner.text == 'Constant':
-            self.exterior = macro.Exterior.Constant
-            
-        else:
-            self.exterior = macro.Exterior.Zero
+        self.exterior = macro.Exterior[self.exteriorSpinner.text]
             
         # Enable constanttextinput if choice is Constant
         if self.exterior == macro.Exterior.Constant:
@@ -1210,76 +1203,23 @@ class LedsStageProgramWidget(BoxLayout):
         p4x = float(self.p4x.text)
         p4y = float(self.p4y.text)
         p4v = float(self.p4v.text)
-        self.exteriorConstant = float(self.constanttextinput.text)
+        exteriorConstant = float(self.constanttextinput.text)
 
         p1 = Vertex2D(np.array([p1x, p1y], np.float32), p1v, 'P1')
         p2 = Vertex2D(np.array([p2x, p2y], np.float32), p2v, 'P2')
         p3 = Vertex2D(np.array([p3x, p3y], np.float32), p3v, 'P3')
         p4 = Vertex2D(np.array([p4x, p4y], np.float32), p4v, 'P4')
 
-        # Sort points by its angle
-        self.quadVertex = [p1, p2, p3, p4]
-        center = (p1.point + p2.point + p3.point + p4.point) / 4
-        self.quadVertex.sort(key= lambda vertex: math.atan2(vertex.point[1] - center[1], vertex.point[0] - center[0]))
-        # Now the points are sorted in anti-clockwise order starting from btmLeft: btmLeft ,btmRight ,topRight ,topRight
+        quadVertex = [p1, p2, p3, p4]
 
-        # Compute value map
-        valMap = np.zeros([160 + 1, 160 + 1, 1], np.float32)
-        for y in range(valMap.shape[0]):
-            for x in range(valMap.shape[1]):
+        # Update DAQStageProgram variables
+        self.app.daqControl.daqStageProgram.update(quadVertex= quadVertex, exterior= self.exterior, exteriorConstant= exteriorConstant)
 
-                val = Vertex2D.bilerp(self.quadVertex[0], self.quadVertex[1], self.quadVertex[2], self.quadVertex[3], np.array([x, y], np.float32), self.exterior, self.exteriorConstant)
-
-                # Clamp between 0, 5 vol
-                val = min(max(0, val), 5)
-                
-                valMap[y, x] = val
-
-
-        # Plot value map
-        plottedImage = self._genPlotVizImg(self.quadVertex, valMap)
+        # Generate value map plot
+        valMapPlot = self.app.daqControl.daqStageProgram.generateValueMapPlot()
         
         # Show the plot
-        self.ids.visualizationplot.texture = imageToTexture(plottedImage)
-    
-
-    def _genPlotVizImg(self, vertices: List[Vertex2D], map: np.ndarray) -> np.ndarray:
-        
-        # Create the plot
-        fig = plt.figure(figsize=(6, 6))
-        
-        # Plot map
-        im = plt.imshow(map, cmap= 'magma')
-        plt.colorbar(im)
-        
-        # Plot 4 points
-        def drawPointWithAnnotation(point: List[float], color: str, name: str) -> None:
-            plt.scatter(point[0], point[1], c= color)
-            plt.annotate(name, (point[0], point[1]), textcoords= 'offset points', xytext= (10,10), ha= 'center', fontsize= 12, color= 'green')
-        
-        drawPointWithAnnotation(vertices[0].point, 'r', vertices[0].name)
-        drawPointWithAnnotation(vertices[1].point, 'r', vertices[1].name)
-        drawPointWithAnnotation(vertices[2].point, 'r', vertices[2].name)
-        drawPointWithAnnotation(vertices[3].point, 'r', vertices[3].name)
-
-        # Set plot limits and labels
-        plt.xlim(0, 160)
-        plt.ylim(0, 160)
-        plt.xlabel('X')
-        plt.ylabel('Y')
-
-        # Add grid and legend
-        plt.grid(True)
-
-        # Render the plot to a numpy array
-        canvas = FigureCanvasAgg(fig)
-        canvas.draw()
-        width, height = fig.get_size_inches() * fig.get_dpi()
-        imageArr = np.frombuffer(canvas.tostring_argb(), dtype='uint8').reshape(int(height), int(width), 4)
-        # Remove alpha channel at the front
-        imageArr = imageArr[:,:,1:4]
-
-        return imageArr
+        self.ids.visualizationplot.texture = imageToTexture(valMapPlot)
     
 
 class LedsStageTextInput(TextInput):
@@ -2199,7 +2139,8 @@ class RecordButton(ImageAcquisitionButton):
 
             imageAcquisitionManager: ImageAcquisitionManager = self.parent
 
-            self.app.daqControl.triggerCommand(frameNum= self.runtimeControls.framecounter.value, frameTime= imageAcquisitionManager.currentTime - imageAcquisitionManager.startTime)
+            self.app.coords
+            self.app.daqControl.update(frameNum= self.runtimeControls.framecounter.value, frameTime= imageAcquisitionManager.currentTime - imageAcquisitionManager.startTime, stagePosition= self.app.coords)
 
         super().receiveImageCallback()
     

--- a/glowtracker/GlowTracker.py
+++ b/glowtracker/GlowTracker.py
@@ -48,8 +48,9 @@ from kivy.uix.settings import SettingsWithSidebar, SettingItem, SettingNumeric
 from kivy.uix.textinput import TextInput
 from kivy.uix.codeinput import CodeInput
 from kivy.uix.slider import Slider
-from kivy.uix.behaviors import DragBehavior
+from kivy.uix.behaviors import DragBehavior, FocusBehavior
 from kivy.uix.switch import Switch
+from kivy.uix.spinner import Spinner
 
 # 
 # IO, Utils
@@ -1108,6 +1109,7 @@ class LedsStageProgramWidget(BoxLayout):
     """Widget that holds the parser and the function handler
     """
     closeCallback = ObjectProperty(None)
+    exterior: Spinner
     constanttextinput: TextInput
     p1x: TextInput; p1y: TextInput; p1v: TextInput
     p2x: TextInput; p2y: TextInput; p2v: TextInput
@@ -1137,7 +1139,18 @@ class LedsStageProgramWidget(BoxLayout):
         self.closeCallback = closeCallback
     
 
+    def updateExteriorChoice(self, *args) ->None:
+        # Enable constanttextinput if choice is Constant
+        if self.exterior.text == 'Constant':
+            self.constanttextinput.disabled = False
+        else:
+            self.constanttextinput.disabled = True
+        
+        self.updateLedStageProgram()
+
+
     def updateLedStageProgram(self) -> None:
+        print('Update value')
         pass
     
 
@@ -1189,6 +1202,43 @@ class LedsStageProgramEnableSwitch(Switch):
             self.app.config.write()
             
             return True
+
+
+class LedsStageTextInput(TextInput):
+    configKey = StringProperty()
+
+    @override
+    def on_kv_post(self, *args):
+        app = App.get_running_app()
+        self.text = app.config.get('LedsControl', self.configKey)
+
+
+    @override
+    def on_text_validate(self, *args):
+        """Save value to config
+        """
+        app = App.get_running_app()
+        app.config.set('LedsControl', self.configKey, float(self.text))
+        app.config.write()
+    
+
+    @override
+    def keyboard_on_key_down(self, window, keycode, text, modifiers):
+        """Intercept Tab to also validate the value
+        """
+        if keycode[1] == 'tab':
+            # Validate (same as pressing Enter)
+            self.dispatch('on_text_validate')
+
+            # Move focus to next widget
+            self.focus = False
+            next_focus = self.get_focus_next()
+            if next_focus:
+                next_focus.focus = True
+
+            return True
+
+        return super().keyboard_on_key_down(window, keycode, text, modifiers)
 
 
 class StageAxisController(BoxLayout):
@@ -3857,7 +3907,21 @@ class GlowTrackerApp(App):
         config.setdefaults('LedsControl', {
             'recentscript': '',
             'isenablesequencer': 'false',
-            'isenablestageprogram': 'false'
+            'isenablestageprogram': 'false',
+            'exterior': 'Zero',
+            'constanttextinput': 0,
+            'p1x': 0,
+            'p1y': 0,
+            'p1v': 0,
+            'p2x': 0,
+            'p2y': 0,
+            'p2v': 0,
+            'p3x': 0,
+            'p3y': 0,
+            'p3v': 0,
+            'p4x': 0,
+            'p4y': 0,
+            'p4v': 0,
         })
 
         config.setdefaults('Developer', {

--- a/glowtracker/GlowTracker.py
+++ b/glowtracker/GlowTracker.py
@@ -71,6 +71,7 @@ import platformdirs
 import shutil
 from pyparsing import ParseException
 import matplotlib.pyplot as plt
+from matplotlib.backends.backend_agg import FigureCanvasAgg
 from dataclasses import dataclass
 
 
@@ -79,6 +80,7 @@ from dataclasses import dataclass
 # 
 from Zaber_control import Stage, AxisEnum
 import Microscope_macros as macro
+from Microscope_macros import Vertex2D
 import Basler_control as basler
 from MacroScript import MacroScriptExecutor
 from AutoFocus import AutoFocusPID, FocusEstimationMethod
@@ -1109,7 +1111,7 @@ class LedsStageProgramWidget(BoxLayout):
     """Widget that holds the parser and the function handler
     """
     closeCallback = ObjectProperty(None)
-    exterior: Spinner
+    exteriorSpinner: Spinner
     constanttextinput: TextInput
     p1x: TextInput; p1y: TextInput; p1v: TextInput
     p2x: TextInput; p2y: TextInput; p2v: TextInput
@@ -1127,6 +1129,7 @@ class LedsStageProgramWidget(BoxLayout):
         self.stage = self.app.stage
         self.camera = self.app.camera
         self.imageAcquisitionManager: ImageAcquisitionManager = self.app.root.ids.middlecolumn.ids.runtimecontrols.imageacquisitionmanager
+        self.exterior = macro.Exterior.Zero
         self._popup: Popup = None
 
     
@@ -1139,19 +1142,113 @@ class LedsStageProgramWidget(BoxLayout):
         self.closeCallback = closeCallback
     
 
-    def updateExteriorChoice(self, *args) ->None:
+    def updateExteriorChoice(self) ->None:
+
+        # Parse choice text to enum
+        if self.exteriorSpinner.text == 'Constant':
+            self.exterior = macro.Exterior.Constant
+            
+        elif self.exteriorSpinner.text == 'Zero':
+            self.exterior = macro.Exterior.Zero
+            
+        else:
+            self.exterior = macro.Exterior.Nearest
+
         # Enable constanttextinput if choice is Constant
-        if self.exterior.text == 'Constant':
+        if self.exterior == macro.Exterior.Constant:
             self.constanttextinput.disabled = False
         else:
             self.constanttextinput.disabled = True
         
-        self.updateLedStageProgram()
-
 
     def updateLedStageProgram(self) -> None:
-        print('Update value')
-        pass
+        # Parse values
+        p1x = float(self.p1x.text)
+        p1y = float(self.p1y.text)
+        p1v = float(self.p1v.text)
+        p2x = float(self.p2x.text)
+        p2y = float(self.p2y.text)
+        p2v = float(self.p2v.text)
+        p3x = float(self.p3x.text)
+        p3y = float(self.p3y.text)
+        p3v = float(self.p3v.text)
+        p4x = float(self.p4x.text)
+        p4y = float(self.p4y.text)
+        p4v = float(self.p4v.text)
+        exteriorConstant = float(self.constanttextinput.text)
+
+        p1 = Vertex2D(np.array([p1x, p1y], np.float32), p1v, 'P1')
+        p2 = Vertex2D(np.array([p2x, p2y], np.float32), p2v, 'P2')
+        p3 = Vertex2D(np.array([p3x, p3y], np.float32), p3v, 'P3')
+        p4 = Vertex2D(np.array([p4x, p4y], np.float32), p4v, 'P4')
+
+        # Sort points by its angle
+        vertices = [p1, p2, p3, p4]
+        vertices.sort(key= lambda vertex: math.atan2(vertex.point[1], vertex.point[0]))
+        # Now the points are sorted in this order:
+        #   btmLeft = points[0]
+        #   btmRight = points[1]
+        #   topLeft = points[3]
+        #   topRight = points[2]
+        
+        # Compute value map
+        valMap = np.zeros([160 + 1, 160 + 1], np.float32)
+        for y in range(valMap.shape[0]):
+            for x in range(valMap.shape[1]):
+
+                val = Vertex2D.bilerp(vertices[0], vertices[1], vertices[2], vertices[3], np.array([x, y], np.float32), self.exterior, exteriorConstant)
+
+                # Clamp between 0, 5 vol
+                val = min(max(0, x), 5)
+                
+                valMap[y, x] = val
+
+
+        # Plot value map
+        plottedImage = self._genPlotVizImg(vertices, valMap)
+        
+        # Show the plot
+        self.ids.visualizationplot.texture = imageToTexture(plottedImage)
+    
+
+    def _genPlotVizImg(self, vertices: List[Vertex2D], map: np.ndarray) -> np.ndarray:
+        
+        # Create the plot
+        fig = plt.figure(figsize=(6, 6))
+        
+        # Plot map
+        plt.imshow(map, vmin= np.min(map), vmax= np.max(map))
+        
+        # Plot 4 points
+        def drawPointWithAnnotation(point: List[float], color: str, name: str) -> None:
+            plt.scatter(point[0], point[1], c= color)
+            plt.annotate(name, (point[0], point[1]), textcoords= 'offset points', xytext= (10,10), \
+                            ha= 'center', fontsize= 12, color= 'black')
+        
+        drawPointWithAnnotation(vertices[0].point, 'r', vertices[0].name)
+        drawPointWithAnnotation(vertices[1].point, 'r', vertices[1].name)
+        drawPointWithAnnotation(vertices[2].point, 'r', vertices[2].name)
+        drawPointWithAnnotation(vertices[3].point, 'r', vertices[3].name)
+
+        # Set plot limits and labels
+        plt.xlim(0, 160)
+        plt.ylim(0, 160)
+        plt.xlabel('X')
+        plt.ylabel('Y')
+
+        # Add grid and legend
+        plt.grid(True)
+        plt.legend()
+
+        # Render the plot to a numpy array
+        canvas = FigureCanvasAgg(fig)
+        canvas.draw()
+        width, height = fig.get_size_inches() * fig.get_dpi()
+        imageArr = np.frombuffer(canvas.tostring_argb(), dtype='uint8').reshape(int(height), int(width), 4)
+        # Remove alpha channel at the front
+        imageArr = imageArr[:,:,1:4]
+
+        return imageArr
     
 
 class LedsSequencerEnableSwitch(Switch):

--- a/glowtracker/GlowTracker.py
+++ b/glowtracker/GlowTracker.py
@@ -74,7 +74,6 @@ import matplotlib.pyplot as plt
 from matplotlib.backends.backend_agg import FigureCanvasAgg
 from dataclasses import dataclass
 
-
 # 
 # Own classes
 # 
@@ -84,7 +83,7 @@ from Microscope_macros import Vertex2D
 import Basler_control as basler
 from MacroScript import MacroScriptExecutor
 from AutoFocus import AutoFocusPID, FocusEstimationMethod
-from DAQ_control import DAQControl
+from DAQ_control import DAQControl, LEDsMode, SequencerMode, StageProgramMode
 
 # 
 # Math
@@ -412,10 +411,11 @@ class RightColumn(BoxLayout):
         self.app.unbind_keys()
 
         # Create LedsControlTabPanel Widget
-        ledsControlTabPanel = LedsControlTabPanel()
-        ledsControlTabPanel.setCloseCallback(closeCallback= self.dismiss_popup)
+        ledsControlTabPanelHolder = LedsControlTabPanelHolder()
+        ledsControlTabPanelHolder.setCloseCallback(closeCallback= self.dismiss_popup)
         # Launch the widget inside a popup window
-        self._popup = Popup(title= '', separator_height= 0, content= ledsControlTabPanel, size_hint= (0.7, 0.7))
+        self._popup = Popup(title= '', separator_height= 0, content= ledsControlTabPanelHolder, size_hint= (0.7, 0.7))
+
         self._popup.open()
 
 
@@ -957,12 +957,46 @@ class DepthOfFieldCalibration(BoxLayout):
         liveViewButton.state = prevLiveViewButtonState
 
 
+class LedsControlTabPanelHolder(FloatLayout):
+
+    mode: Spinner
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.ids.ledscontroltabpanel.init()
+
+    
+    def setCloseCallback(self, closeCallback: callable) -> None:
+        """API setting close callback event for children' tab.
+
+        Args:
+            closeCallback (callable): the closing callback event.
+        """        
+        self.closeCallback = closeCallback
+        self.ids.ledscontroltabpanel.setCloseCallback( closeCallback )
+    
+    def updateMode(self):
+        print(self.mode.text)
+
+        app: GlowTrackerApp = App.get_running_app()
+
+        # Update to config
+        app.config.set('LedsControl', 'mode', self.mode.text)
+        app.config.write()
+
+        # Update DAQControl
+        app.daqControl.ledsMode = LEDsMode[self.mode.text]
+
+
 class LedsControlTabPanel(TabbedPanel):
     """Calibration widget that holds CameraAndStageCalibration, DualColorCalibration, and DepthOfFieldCalibration
     """    
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
+    
+    
+    def init(self):
         self.ids.ledssequencer.init()
         self.ids.ledsstageprogram.init()
     
@@ -1131,6 +1165,8 @@ class LedsStageProgramWidget(BoxLayout):
         self.imageAcquisitionManager: ImageAcquisitionManager = self.app.root.ids.middlecolumn.ids.runtimecontrols.imageacquisitionmanager
         self.exterior = macro.Exterior.Zero
         self._popup: Popup = None
+        self.quadVertex: List[Vertex2D] = []
+        self.exteriorConstant: float = 0
         self.updateLedStageProgram()
 
     
@@ -1174,7 +1210,7 @@ class LedsStageProgramWidget(BoxLayout):
         p4x = float(self.p4x.text)
         p4y = float(self.p4y.text)
         p4v = float(self.p4v.text)
-        exteriorConstant = float(self.constanttextinput.text)
+        self.exteriorConstant = float(self.constanttextinput.text)
 
         p1 = Vertex2D(np.array([p1x, p1y], np.float32), p1v, 'P1')
         p2 = Vertex2D(np.array([p2x, p2y], np.float32), p2v, 'P2')
@@ -1182,17 +1218,17 @@ class LedsStageProgramWidget(BoxLayout):
         p4 = Vertex2D(np.array([p4x, p4y], np.float32), p4v, 'P4')
 
         # Sort points by its angle
-        vertices = [p1, p2, p3, p4]
+        self.quadVertex = [p1, p2, p3, p4]
         center = (p1.point + p2.point + p3.point + p4.point) / 4
-        vertices.sort(key= lambda vertex: math.atan2(vertex.point[1] - center[1], vertex.point[0] - center[0]))
+        self.quadVertex.sort(key= lambda vertex: math.atan2(vertex.point[1] - center[1], vertex.point[0] - center[0]))
         # Now the points are sorted in anti-clockwise order starting from btmLeft: btmLeft ,btmRight ,topRight ,topRight
-        
+
         # Compute value map
         valMap = np.zeros([160 + 1, 160 + 1, 1], np.float32)
         for y in range(valMap.shape[0]):
             for x in range(valMap.shape[1]):
 
-                val = Vertex2D.bilerp(vertices[0], vertices[1], vertices[2], vertices[3], np.array([x, y], np.float32), self.exterior, exteriorConstant)
+                val = Vertex2D.bilerp(self.quadVertex[0], self.quadVertex[1], self.quadVertex[2], self.quadVertex[3], np.array([x, y], np.float32), self.exterior, self.exteriorConstant)
 
                 # Clamp between 0, 5 vol
                 val = min(max(0, val), 5)
@@ -1201,7 +1237,7 @@ class LedsStageProgramWidget(BoxLayout):
 
 
         # Plot value map
-        plottedImage = self._genPlotVizImg(vertices, valMap)
+        plottedImage = self._genPlotVizImg(self.quadVertex, valMap)
         
         # Show the plot
         self.ids.visualizationplot.texture = imageToTexture(plottedImage)
@@ -1245,56 +1281,6 @@ class LedsStageProgramWidget(BoxLayout):
 
         return imageArr
     
-
-class LedsSequencerEnableSwitch(Switch):
-
-    def __init__(self, **kwargs):
-        super(LedsSequencerEnableSwitch, self).__init__(**kwargs)
-        self.app: GlowTrackerApp = App.get_running_app()
-        self.active = self.app.config.getboolean('LedsControl', 'isenablesequencer')
-    
-
-    def on_touch_up(self, touch): 
-        """On switch touch up callback. Update the config value 'isenablesequencer',
-
-        Args:
-            touch (Touch): touch input data.
-        """
-        # Check if responsible
-        if super(LedsSequencerEnableSwitch, self).on_touch_up(touch):
-
-            if self.app.daqControl is not None:
-                self.app.daqControl.isEnable = self.active
-            self.app.config.set('LedsControl', 'isenablesequencer', int(self.active))
-            self.app.config.write()
-            
-            return True
-
-
-class LedsStageProgramEnableSwitch(Switch):
-
-    def __init__(self, **kwargs):
-        super(LedsStageProgramEnableSwitch, self).__init__(**kwargs)
-        self.app: GlowTrackerApp = App.get_running_app()
-        self.active = self.app.config.getboolean('LedsControl', 'isenablestageprogram')
-    
-
-    def on_touch_up(self, touch): 
-        """On switch touch up callback. Update the config value 'isenablestageprogram',
-
-        Args:
-            touch (Touch): touch input data.
-        """
-        # Check if responsible
-        if super(LedsStageProgramEnableSwitch, self).on_touch_up(touch):
-
-            if self.app.daqControl is not None:
-                self.app.daqControl.isEnable = self.active
-            self.app.config.set('LedsControl', 'isenablestageprogram', int(self.active))
-            self.app.config.write()
-            
-            return True
-
 
 class LedsStageTextInput(TextInput):
     configKey = StringProperty()
@@ -1937,7 +1923,7 @@ class RecordButton(ImageAcquisitionButton):
         self.savingthread.start()
 
         # Prep DAQ control
-        if self.app.daqControl is not None and self.app.daqControl.isEnable:
+        if self.app.daqControl is not None and self.app.daqControl.ledsMode != LEDsMode.Off:
             self.app.daqControl.start()
 
         # Setup image acquisition thread parameters
@@ -2109,7 +2095,7 @@ class RecordButton(ImageAcquisitionButton):
         Clock.schedule_once( resumeButtonsState )
 
         # Reset the DAQ state
-        if self.app.daqControl is not None and self.app.daqControl.isEnable:
+        if self.app.daqControl is not None and self.app.daqControl.ledsMode != LEDsMode.Off:
             self.app.daqControl.reset()
     
 
@@ -2209,7 +2195,7 @@ class RecordButton(ImageAcquisitionButton):
 
         # Trigger DAQ Control command
         # Actually, is framecounter.value effected when frame skip?
-        if self.app.daqControl is not None and self.app.daqControl.isEnable:
+        if self.app.daqControl is not None and self.app.daqControl.ledsMode != LEDsMode.Off:
 
             imageAcquisitionManager: ImageAcquisitionManager = self.parent
 
@@ -2228,7 +2214,7 @@ class RecordButton(ImageAcquisitionButton):
         print(f'Recorded {self.numberRecordframes} frames.')
 
         # Reset the DAQ state
-        if self.app.daqControl is not None and self.app.daqControl.isEnable:
+        if self.app.daqControl is not None and self.app.daqControl.ledsMode != LEDsMode.Off:
             self.app.daqControl.reset()
 
         # Call to recording-stopping procedure
@@ -3769,7 +3755,7 @@ class Connections(BoxLayout):
             self.daq_connection.state = 'normal'
             return
         
-        app.daqControl.isEnable = app.config.getboolean("LedsControl", "isenable")
+        app.daqControl.ledsMode = LEDsMode[app.config.get("LedsControl", "mode")]
 
         # Load recent script
         try:
@@ -3996,9 +3982,9 @@ class GlowTrackerApp(App):
         })
 
         config.setdefaults('LedsControl', {
+            'mode': 'Off',
             'ledsequencescript': '',
-            'isenablesequencer': 'false',
-            'isenablestageprogram': 'false',
+            'stageprogrammode': 'FourPoint',
             'exterior': 'Zero',
             'constanttextinput': 0,
             'p1x': 0,
@@ -4414,12 +4400,9 @@ class GlowTrackerApp(App):
 
         elif section == 'LedsControl':
 
-            if key == 'isenablesequencer':
-                self.daqControl.isEnable = bool(int(value))
+            if key == 'mode':
 
-
-            if key == 'isenablestageprogram':
-                self.daqControl.isEnable = bool(int(value))
+                self.daqControl.ledsMode = LEDsMode[value]
 
 
         elif section == 'Developer':

--- a/glowtracker/GlowTracker.py
+++ b/glowtracker/GlowTracker.py
@@ -992,7 +992,8 @@ class LedsControlTabPanelHolder(FloatLayout):
         app.config.write()
 
         # Update DAQControl
-        app.daqControl.ledsMode = LEDsMode[self.mode.text]
+        if app.daqControl:
+            app.daqControl.ledsMode = LEDsMode[self.mode.text]
 
 
 class LedsControlTabPanel(TabbedPanel):
@@ -1058,7 +1059,13 @@ class LedsControlWidget(BoxLayout):
         """
         
         loadWidget = LoadScriptWidget(load= self._loadScriptWidgetCallback)
-        self._popup = Popup(title= "Load macro script file", content= loadWidget,
+
+        # Check if current file path is not empty then go to that path at the beginning,
+        #  and set loadWidget.ids.filechooser.path = ...
+        if self.ledsScriptFile != '':
+            loadWidget.ids.filechooser.path = self.ledsScriptFile
+
+        self._popup = Popup(title= "Load sequence file", content= loadWidget,
             size_hint= (0.9, 0.9), auto_dismiss= False)
 
         loadWidget.cancel = self._popup.dismiss
@@ -1114,7 +1121,13 @@ class LedsControlWidget(BoxLayout):
 
         # Parse text to command
         if self.app.daqControl is not None:
-            self.app.daqControl.parseTextScript(self.ledsScript)
+            
+            try:
+                self.app.daqControl.parseTextScript(self.ledsScript)
+
+            except Exception as e:
+                print(e)
+                return None
         
 
     def saveScript(self):
@@ -4514,7 +4527,8 @@ class GlowTrackerApp(App):
 
             if key == 'mode':
 
-                self.daqControl.ledsMode = LEDsMode[value]
+                if self.daqControl:
+                    self.daqControl.ledsMode = LEDsMode[value]
 
 
         elif section == 'Developer':

--- a/glowtracker/GlowTracker.py
+++ b/glowtracker/GlowTracker.py
@@ -1596,7 +1596,7 @@ class ImageAcquisitionButton(ToggleButton):
         - startImageAcuisition()
         - acquisitionCondition()
 
-    in order to be functionable.
+    in order to be functional.
     """    
     
     def __init__(self, **kwargs):
@@ -1662,7 +1662,7 @@ class ImageAcquisitionButton(ToggleButton):
         # reset scale of image
         self.app.root.ids.middlecolumn.ids.scalableimage.reset()
 
-        # Set self button state to normal
+        # Set self button state to normal.
         self.state = 'normal'
     
 
@@ -1949,7 +1949,29 @@ class RecordButton(ImageAcquisitionButton):
         self.imageFilenameExtension: str = ''
         self.prevLiveViewButtonState: str = ''
         self.prevLiveAnalysisButtonState: str = ''
-    
+        
+
+    @override
+    def on_state(self, widget: Widget, state: str):
+        """On state change callback
+
+        Args:
+            widget (Widget): the kivy widget, in this case is the same as the class instance itself.
+            state (str): the new state
+        """        
+        self.app: GlowTrackerApp = App.get_running_app()
+        self.camera = self.app.camera
+
+        if self.camera is None:
+            return
+
+        if state == 'down':
+            self.startImageAcquisition()
+            
+        else:
+            if self.camera.IsGrabbing():
+                self.stopImageAcquisition()
+            
 
     @override
     def startImageAcquisition(self) -> None:
@@ -2140,8 +2162,12 @@ class RecordButton(ImageAcquisitionButton):
         if self.prevLiveViewButtonState == 'down':
             self.camera.setIsOnHold(True)
 
+        print(f'Recorded {self.runtimeControls.framecounter.value} frames')
+
         # Stop the camera and clear values
         super().stopImageAcquisition()
+
+        print('Stopped recording')
 
         # Schedule closing coordinate file a bit later
         Clock.schedule_once(lambda dt: self.coordinateFile.close(), 0.5)
@@ -2151,7 +2177,6 @@ class RecordButton(ImageAcquisitionButton):
             self.imageQueue.put(None)
             self.savingthread.join()
 
-        print("Stop recording")
 
         # Set LiveView button state back to enable.
         #   We need to do it here as a schedule event. Because this current function (stopImageAcquisition)
@@ -2287,14 +2312,17 @@ class RecordButton(ImageAcquisitionButton):
         # Send signal to terminate recording workers
         self.imageQueue.put(None)
 
-        print(f'Recorded {self.numberRecordframes} frames.')
-
         # Reset the DAQ state
         if self.app.daqControl is not None and self.app.daqControl.ledsMode != LEDsMode.Off:
             self.app.daqControl.reset()
 
-        # Call to recording-stopping procedure
-        self.stopImageAcquisition()
+        # There are two ways to reach this point:
+        #   a. Manually stop recording by clicking the Record button
+        #   b. Automatically after recorded target number of frames.
+        # We can distinguish between them by checking self.state
+        # In case b.) the button state will still be 'down' and therefore we need to call stopImageAcquisition() procedure.
+        if self.state == 'down':
+            self.stopImageAcquisition()
     
 
     def initRecordingParams(self):

--- a/glowtracker/GlowTracker.py
+++ b/glowtracker/GlowTracker.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 # Suppress kivy normal initialization logs in the beginning
 # for easier debugging
@@ -51,6 +53,7 @@ from kivy.uix.slider import Slider
 from kivy.uix.behaviors import DragBehavior, FocusBehavior
 from kivy.uix.switch import Switch
 from kivy.uix.spinner import Spinner
+from kivy.uix.stacklayout import StackLayout
 
 # 
 # IO, Utils
@@ -82,7 +85,7 @@ from Microscope_macros import Vertex2D
 import Basler_control as basler
 from MacroScript import MacroScriptExecutor
 from AutoFocus import AutoFocusPID, FocusEstimationMethod
-from DAQ_control import DAQControl, LEDsMode, SequencerMode, StageProgramMode
+from DAQ_control import DAQControl, LEDsMode, StageProgramMode, GaussianParams
 
 # 
 # Math
@@ -92,6 +95,9 @@ import numpy as np
 from skimage.io import imsave
 import cv2
 from scipy.stats import skew
+
+import gc
+
 
 # helper functions
 def timeStamped(fname, fmt='%Y-%m-%d-%H-%M-%S-%f-{fname}'):
@@ -1145,11 +1151,30 @@ class LedsStageProgramWidget(BoxLayout):
     """
     closeCallback = ObjectProperty(None)
     exteriorSpinner: Spinner
-    constanttextinput: TextInput
-    p1x: TextInput; p1y: TextInput; p1v: TextInput
-    p2x: TextInput; p2y: TextInput; p2v: TextInput
-    p3x: TextInput; p3y: TextInput; p3v: TextInput
-    p4x: TextInput; p4y: TextInput; p4v: TextInput
+    modeSpinner: Spinner
+    # FourPoint params
+    constanttextinput: LedsStageTextInput
+    p1x: LedsStageTextInput; p1y: LedsStageTextInput; p1v: LedsStageTextInput
+    p2x: LedsStageTextInput; p2y: LedsStageTextInput; p2v: LedsStageTextInput
+    p3x: LedsStageTextInput; p3y: LedsStageTextInput; p3v: LedsStageTextInput
+    p4x: LedsStageTextInput; p4y: LedsStageTextInput; p4v: LedsStageTextInput
+    exterior_layout: BoxLayout
+    fourpoint_header_layout: BoxLayout
+    p1_layout: BoxLayout
+    p2_layout: BoxLayout
+    p3_layout: BoxLayout
+    p4_layout: BoxLayout
+    # Gaussian Params
+    g_amplitude: LedsStageTextInput
+    g_x_mean: LedsStageTextInput
+    g_x_sigma: LedsStageTextInput
+    g_y_mean: LedsStageTextInput
+    g_y_sigma: LedsStageTextInput
+    g_amplitude_layout: BoxLayout
+    g_x_mean_layout: BoxLayout
+    g_x_sigma_layout: BoxLayout
+    g_y_mean_layout: BoxLayout
+    g_y_sigma_layout: BoxLayout
 
     def __init__(self, **kwargs):
         super(LedsStageProgramWidget, self).__init__(**kwargs)
@@ -1157,13 +1182,17 @@ class LedsStageProgramWidget(BoxLayout):
 
     def init(self):
         
-        # Initialize MacroScriptExecutor
+        # Initialize 
         self.app: GlowTrackerApp = App.get_running_app()
         self.stage = self.app.stage
         self.camera = self.app.camera
         self.imageAcquisitionManager: ImageAcquisitionManager = self.app.root.ids.middlecolumn.ids.runtimecontrols.imageacquisitionmanager
         self.exterior = macro.Exterior.Zero
+        self.mode = StageProgramMode.FourPoint
         self._popup: Popup = None
+        self.fourPointParamWidgets = [self.exterior_layout, self.fourpoint_header_layout, self.p1_layout, self.p2_layout, self.p3_layout, self.p4_layout]
+        self.gaussianPointParamsWidgets = [self.g_amplitude_layout, self.g_x_mean_layout, self.g_x_sigma_layout, self.g_y_mean_layout, self.g_y_sigma_layout]
+        self.initModeWidget()
         self.updateLedStageProgram()
 
     
@@ -1174,9 +1203,25 @@ class LedsStageProgramWidget(BoxLayout):
             closeCallback (callable): the closing callback.
         """        
         self.closeCallback = closeCallback
-    
 
-    def updateExteriorChoice(self) ->None:
+    
+    def initModeWidget(self) -> None:
+        """On startup gui, remove other modes' unrelated widgets
+        """
+        stacklayout: StackLayout = self.ids.stacklayout
+
+        if self.mode == StageProgramMode.FourPoint:
+            # Remove Gaussian params widgets
+            for widget in self.gaussianPointParamsWidgets:
+                stacklayout.remove_widget(widget= widget)
+            
+        elif self.mode == StageProgramMode.Gaussian:
+            # Remove FourPoint params widgets
+            for widget in self.fourPointParamWidgets:
+                stacklayout.remove_widget(widget= widget)
+        
+
+    def updateExteriorChoice(self) -> None:
 
         # Parse choice text to enum
         self.exterior = macro.Exterior[self.exteriorSpinner.text]
@@ -1188,32 +1233,68 @@ class LedsStageProgramWidget(BoxLayout):
         else:
             self.constanttextinput.disabled = True
         
+    
+    def updateMode(self) -> None:
+
+        # Parse choice text to enum
+        prevMode = self.mode
+        self.mode = StageProgramMode[self.modeSpinner.text]
+
+        # Update GUI
+        if prevMode != self.mode:
+
+            stacklayout: StackLayout = self.ids.stacklayout
+
+            if self.mode == StageProgramMode.FourPoint:
+                # Remove Gaussian params widgets
+                for widget in self.gaussianPointParamsWidgets:
+                    stacklayout.remove_widget(widget= widget)
+                
+                # Add FourPoint params widgets
+                for widget in self.fourPointParamWidgets:
+                    stacklayout.add_widget(widget= widget)
+
+            elif self.mode == StageProgramMode.Gaussian:
+                
+                # Remove FourPoint params widgets
+                for widget in self.fourPointParamWidgets:
+                    stacklayout.remove_widget(widget= widget)
+                
+                # Add Gaussian params widgets
+                for widget in self.gaussianPointParamsWidgets:
+                    stacklayout.add_widget(widget= widget)
+        
+        # Save to config
+        self.app.config.set('LedsControl', 'stageprogrammode', self.modeSpinner.text)
+        self.app.config.write()
+
 
     def updateLedStageProgram(self) -> None:
-        # Parse values
-        p1x = float(self.p1x.text)
-        p1y = float(self.p1y.text)
-        p1v = float(self.p1v.text)
-        p2x = float(self.p2x.text)
-        p2y = float(self.p2y.text)
-        p2v = float(self.p2v.text)
-        p3x = float(self.p3x.text)
-        p3y = float(self.p3y.text)
-        p3v = float(self.p3v.text)
-        p4x = float(self.p4x.text)
-        p4y = float(self.p4y.text)
-        p4v = float(self.p4v.text)
-        exteriorConstant = float(self.constanttextinput.text)
 
-        p1 = Vertex2D(np.array([p1x, p1y], np.float32), p1v, 'P1')
-        p2 = Vertex2D(np.array([p2x, p2y], np.float32), p2v, 'P2')
-        p3 = Vertex2D(np.array([p3x, p3y], np.float32), p3v, 'P3')
-        p4 = Vertex2D(np.array([p4x, p4y], np.float32), p4v, 'P4')
+        if self.mode == StageProgramMode.FourPoint:
+            # Parse values
+            p1 = Vertex2D(np.array([self.p1x.value, self.p1y.value], np.float32), self.p1v.value, 'P1')
+            p2 = Vertex2D(np.array([self.p2x.value, self.p2y.value], np.float32), self.p2v.value, 'P2')
+            p3 = Vertex2D(np.array([self.p3x.value, self.p3y.value], np.float32), self.p3v.value, 'P3')
+            p4 = Vertex2D(np.array([self.p4x.value, self.p4y.value], np.float32), self.p4v.value, 'P4')
 
-        quadVertex = [p1, p2, p3, p4]
+            quadVertex = [p1, p2, p3, p4]
 
-        # Update DAQStageProgram variables
-        self.app.daqControl.daqStageProgram.update(quadVertex= quadVertex, exterior= self.exterior, exteriorConstant= exteriorConstant)
+            # Update DAQStageProgram variables
+            self.app.daqControl.daqStageProgram.update(mode= self.mode, quadVertex= quadVertex, exterior= self.exterior, exteriorConstant= self.constanttextinput.value)
+
+        elif self.mode == StageProgramMode.Gaussian: 
+            # Parse values
+            gaussianParams = GaussianParams(
+                amplitude= self.g_amplitude.value,
+                x_mean= self.g_x_mean.value,
+                x_sigma= self.g_x_sigma.value,
+                y_mean= self.g_y_mean.value,
+                y_sigma= self.g_y_sigma.value
+            )
+
+            # Update DAQStageProgram variables
+            self.app.daqControl.daqStageProgram.update(mode= self.mode, gaussianParams= gaussianParams)
 
         # Generate value map plot
         valMapPlot = self.app.daqControl.daqStageProgram.generateValueMapPlot()
@@ -1224,19 +1305,53 @@ class LedsStageProgramWidget(BoxLayout):
 
 class LedsStageTextInput(TextInput):
     configKey = StringProperty()
+    root = ObjectProperty()     # Reference to root, which should be LedsStageProgramWidget
 
     def on_kv_post(self, *args):
-        app = App.get_running_app()
-        self.text = app.config.get('LedsControl', self.configKey)
+        self.app = App.get_running_app()
+        self.text = self.app.config.get('LedsControl', self.configKey)
+        self.value = float(self.text)
+
+
+    def _validate(self) -> bool:
+        """Validate if self.text can be interpreted as a numerical value. If successful, self.value is updated.
+        
+        Returns:
+            bool: True if a number. Otherwise, False.
+        """
+        value_float = float(0)
+
+        # Check if input is a number
+        try:
+            value_float = float(self.text)
+
+        except ValueError:
+            # The value is not a number
+            return False
+        
+        # Check if should display text in integer style or floating point style
+        try:
+            value_int = int(self.text)
+            self.value = value_int
+
+        except ValueError:
+            # We are here because we couldn't cast the value string to int, thus the value is a float
+            self.value = value_float
+
+        return True
 
 
     @override
     def on_text_validate(self, *args):
-        """Save value to config
+        """Validate self.text. Then save to config and update LedStageProgram.
         """
-        app = App.get_running_app()
-        app.config.set('LedsControl', self.configKey, float(self.text))
-        app.config.write()
+        if self._validate():
+            self.app.config.set('LedsControl', self.configKey, self.value)
+            self.app.config.write()
+            self.root.updateLedStageProgram()
+        
+        else:
+            self.text = str(self.value)
     
 
     @override
@@ -3727,6 +3842,12 @@ class Connections(BoxLayout):
         p4x = app.config.getfloat('LedsControl', 'p4x')
         p4y = app.config.getfloat('LedsControl', 'p4y')
         p4v = app.config.getfloat('LedsControl', 'p4v')
+        g_amplitude = app.config.getfloat('LedsControl', 'g_amplitude')
+        g_x_mean = app.config.getfloat('LedsControl', 'g_x_mean')
+        g_x_sigma = app.config.getfloat('LedsControl', 'g_x_sigma')
+        g_y_mean = app.config.getfloat('LedsControl', 'g_y_mean')
+        g_y_sigma = app.config.getfloat('LedsControl', 'g_y_sigma')
+        gaussianParams = GaussianParams(amplitude= g_amplitude, x_mean= g_x_mean, x_sigma= g_x_sigma, y_mean= g_y_mean, y_sigma= g_y_sigma)
 
         p1 = Vertex2D(np.array([p1x, p1y], np.float32), p1v, 'P1')
         p2 = Vertex2D(np.array([p2x, p2y], np.float32), p2v, 'P2')
@@ -3736,7 +3857,7 @@ class Connections(BoxLayout):
         quadVertex = [p1, p2, p3, p4]
 
         # Update DAQStageProgram variables
-        app.daqControl.daqStageProgram.update(mode= stageprogrammode, quadVertex= quadVertex, exterior= exterior, exteriorConstant= exteriorConstant)
+        app.daqControl.daqStageProgram.update(mode= stageprogrammode, quadVertex= quadVertex, exterior= exterior, exteriorConstant= exteriorConstant, gaussianParams= gaussianParams)
 
 
     def disconnectDaq(self):
@@ -3967,6 +4088,11 @@ class GlowTrackerApp(App):
             'p4x': 0,
             'p4y': 0,
             'p4v': 0,
+            'g_amplitude': 0,
+            'g_x_mean': 0,
+            'g_x_sigma': 0,
+            'g_y_mean': 0,
+            'g_y_sigma': 0
         })
 
         config.setdefaults('Developer', {

--- a/glowtracker/GlowTracker.py
+++ b/glowtracker/GlowTracker.py
@@ -1108,7 +1108,11 @@ class LedsStageProgramWidget(BoxLayout):
     """Widget that holds the parser and the function handler
     """
     closeCallback = ObjectProperty(None)
+    constanttextinput: TextInput
     p1x: TextInput; p1y: TextInput; p1v: TextInput
+    p2x: TextInput; p2y: TextInput; p2v: TextInput
+    p3x: TextInput; p3y: TextInput; p3v: TextInput
+    p4x: TextInput; p4y: TextInput; p4v: TextInput
 
     def __init__(self, **kwargs):
         super(LedsStageProgramWidget, self).__init__(**kwargs)
@@ -1134,7 +1138,6 @@ class LedsStageProgramWidget(BoxLayout):
     
 
     def updateLedStageProgram(self) -> None:
-        self.p1x.te
         pass
     
 

--- a/glowtracker/GlowTracker.py
+++ b/glowtracker/GlowTracker.py
@@ -1175,19 +1175,23 @@ class LedsStageProgramWidget(BoxLayout):
     """
     closeCallback = ObjectProperty(None)
     exteriorSpinner: Spinner
-    modeSpinner: Spinner
+
     # FourPoint params
+    modeSpinner: Spinner
     constanttextinput: LedsStageTextInput
     p1x: LedsStageTextInput; p1y: LedsStageTextInput; p1v: LedsStageTextInput
     p2x: LedsStageTextInput; p2y: LedsStageTextInput; p2v: LedsStageTextInput
     p3x: LedsStageTextInput; p3y: LedsStageTextInput; p3v: LedsStageTextInput
     p4x: LedsStageTextInput; p4y: LedsStageTextInput; p4v: LedsStageTextInput
+    relative: Switch
     exterior_layout: BoxLayout
     fourpoint_header_layout: BoxLayout
     p1_layout: BoxLayout
     p2_layout: BoxLayout
     p3_layout: BoxLayout
     p4_layout: BoxLayout
+    relative_layout: BoxLayout
+
     # Gaussian Params
     g_amplitude: LedsStageTextInput
     g_x_mean: LedsStageTextInput
@@ -1218,7 +1222,7 @@ class LedsStageProgramWidget(BoxLayout):
         self.modeSpinner.text = self.mode.value
         self._popup: Popup = None
         
-        self.fourPointParamWidgets = [self.exterior_layout, self.fourpoint_header_layout, self.p1_layout, self.p2_layout, self.p3_layout, self.p4_layout]
+        self.fourPointParamWidgets = [self.exterior_layout, self.fourpoint_header_layout, self.p1_layout, self.p2_layout, self.p3_layout, self.p4_layout, self.relative_layout]
         
         self.gaussianPointParamsWidgets = [self.g_amplitude_layout, self.g_x_mean_layout, self.g_x_sigma_layout, self.g_y_mean_layout, self.g_y_sigma_layout, self.g_relative_layout]
         
@@ -1311,7 +1315,7 @@ class LedsStageProgramWidget(BoxLayout):
             quadVertex = [p1, p2, p3, p4]
 
             # Update DAQStageProgram variables
-            self.app.daqControl.daqStageProgram.update(mode= self.mode, quadVertex= quadVertex, exterior= self.exterior, exteriorConstant= self.constanttextinput.value)
+            self.app.daqControl.daqStageProgram.update(mode= self.mode, quadVertex= quadVertex, exterior= self.exterior, exteriorConstant= self.constanttextinput.value, isFourPointRelative= self.relative.active)
 
         elif self.mode == StageProgramMode.Gaussian: 
             # Parse values
@@ -1333,7 +1337,7 @@ class LedsStageProgramWidget(BoxLayout):
         self.ids.visualizationplot.texture = imageToTexture(valMapPlot)
 
 
-class GaussianRelativePositionSwitch(Switch):
+class RelativePositionSwitch(Switch):
     configKey = StringProperty()
     root = ObjectProperty()     # Reference to root, which should be LedsStageProgramWidget
 
@@ -1350,7 +1354,7 @@ class GaussianRelativePositionSwitch(Switch):
         Args:
             touch (Touch): touch input data.
         """
-        if super(GaussianRelativePositionSwitch, self).on_touch_up(touch):
+        if super(RelativePositionSwitch, self).on_touch_up(touch):
 
             self.app.config.set('LedsControl', self.configKey, int(self.active))
             self.app.config.write()
@@ -4226,6 +4230,7 @@ class GlowTrackerApp(App):
             'p4x': 0,
             'p4y': 0,
             'p4v': 0,
+            'relative': 'true',
             'g_amplitude': 0,
             'g_x_mean': 0,
             'g_x_sigma': 0,

--- a/glowtracker/GlowTracker.py
+++ b/glowtracker/GlowTracker.py
@@ -72,6 +72,8 @@ from pyparsing import ParseException
 import matplotlib.pyplot as plt
 from dataclasses import dataclass
 import re
+import u3
+
 
 # 
 # Own classes
@@ -3423,12 +3425,12 @@ class Connections(BoxLayout):
     def disconnectCamera(self):
         camera = App.get_running_app().camera
         if camera is not None:
-            print('disconnecting')
+            print('Disconnecting camera')
             camera.Close()
 
 
     def connectStage(self):
-        print('connecting Stage')
+        print('Connecting Stage')
         app = App.get_running_app()
         port = app.config.get('Stage', 'port')
         maxspeed = float( app.config.get('Stage', 'maxspeed') )
@@ -3470,7 +3472,7 @@ class Connections(BoxLayout):
             
 
     def disconnectStage(self):
-        print('disconnecting Stage')
+        print('Disconnecting Stage')
         app = App.get_running_app()
         if app.stage is None:
             self.stage_connection.state = 'normal'
@@ -3481,6 +3483,37 @@ class Connections(BoxLayout):
         app.root.ids.leftcolumn.ids.xcontrols.disable_all()
         app.root.ids.leftcolumn.ids.ycontrols.disable_all()
         app.root.ids.leftcolumn.ids.zcontrols.disable_all()
+    
+
+    def connectDac(self):
+        print('Connecting DAC')
+        app: GlowTrackerApp = App.get_running_app()
+
+        # Connect to device
+        try:
+            device = u3.U3(debug= False)
+
+        except Exception as e:
+            print(e)
+            self.dac_connection.state = 'normal'
+
+        else:
+            print(f"Using {device.deviceName}, serial: {device.serialNumber}")
+            # Set to factory default
+            device.setDefaults()
+            # Calibrate
+            device.getCalibrationData()
+            # Save to App's attr
+            app.dac = device
+
+
+    def disconnectDac(self):
+        print('Disconnecting DAC')
+        app: GlowTrackerApp = App.get_running_app()
+
+        if app.dac is not None:
+            app.dac.close()
+            app.dac = None
 
 
 class MyCounter():
@@ -3549,6 +3582,7 @@ class GlowTrackerApp(App):
         # hardware
         self.camera: basler.Camera | None = None
         self.stage: Stage = Stage(None)
+        self.dac: u3.U3 | None = None
         self.updateFpsEvent = None
     
 

--- a/glowtracker/GlowTracker.py
+++ b/glowtracker/GlowTracker.py
@@ -4463,7 +4463,6 @@ class GlowTrackerApp(App):
 
         # Very crude estimation. Need to consult Monika
         spf = 1 / 30.0
-        print(f"velocity_cm_per_sec {velocity_cm_per_sec}")
         extrapolatedPos = np.array(self.coords) + spf * velocity_cm_per_sec * 10
         self.coords = extrapolatedPos.tolist()
 

--- a/glowtracker/GlowTracker.py
+++ b/glowtracker/GlowTracker.py
@@ -412,7 +412,7 @@ class RightColumn(BoxLayout):
         ledsControlTabPanel = LedsControlTabPanel()
         ledsControlTabPanel.setCloseCallback(closeCallback= self.dismiss_popup)
         # Launch the widget inside a popup window
-        self._popup = Popup(title= '', separator_height= 0, content= ledsControlTabPanel, size_hint= (0.9, 0.75))
+        self._popup = Popup(title= '', separator_height= 0, content= ledsControlTabPanel, size_hint= (0.7, 0.7))
         self._popup.open()
 
 
@@ -1108,6 +1108,7 @@ class LedsStageProgramWidget(BoxLayout):
     """Widget that holds the parser and the function handler
     """
     closeCallback = ObjectProperty(None)
+    p1x: TextInput; p1y: TextInput; p1v: TextInput
 
     def __init__(self, **kwargs):
         super(LedsStageProgramWidget, self).__init__(**kwargs)
@@ -1132,6 +1133,11 @@ class LedsStageProgramWidget(BoxLayout):
         self.closeCallback = closeCallback
     
 
+    def updateLedStageProgram(self) -> None:
+        self.p1x.te
+        pass
+    
+
 class LedsSequencerEnableSwitch(Switch):
 
     def __init__(self, **kwargs):
@@ -1146,11 +1152,15 @@ class LedsSequencerEnableSwitch(Switch):
         Args:
             touch (Touch): touch input data.
         """
-        super(LedsSequencerEnableSwitch, self).on_touch_up(touch)
+        # Check if responsible
+        if super(LedsSequencerEnableSwitch, self).on_touch_up(touch):
 
-        self.app.daqControl.isEnable = self.active
-        self.app.config.set('LedsControl', 'isenablesequencer', int(self.active))
-        self.app.config.write()
+            if self.app.daqControl is not None:
+                self.app.daqControl.isEnable = self.active
+            self.app.config.set('LedsControl', 'isenablesequencer', int(self.active))
+            self.app.config.write()
+            
+            return True
 
 
 class LedsStageProgramEnableSwitch(Switch):
@@ -1167,11 +1177,15 @@ class LedsStageProgramEnableSwitch(Switch):
         Args:
             touch (Touch): touch input data.
         """
-        super(LedsStageProgramEnableSwitch, self).on_touch_up(touch)
+        # Check if responsible
+        if super(LedsStageProgramEnableSwitch, self).on_touch_up(touch):
 
-        self.app.daqControl.isEnable = self.active
-        self.app.config.set('LedsControl', 'isenablestageprogram', int(self.active))
-        self.app.config.write()
+            if self.app.daqControl is not None:
+                self.app.daqControl.isEnable = self.active
+            self.app.config.set('LedsControl', 'isenablestageprogram', int(self.active))
+            self.app.config.write()
+            
+            return True
 
 
 class StageAxisController(BoxLayout):
@@ -1301,21 +1315,17 @@ class ContinuousSwitch(Switch):
         Args:
             touch (Touch): touch input data.
         """
-        super(ContinuousSwitch, self).on_touch_up(touch)
+        if super(ContinuousSwitch, self).on_touch_up(touch):
 
-        recordingSettings: RecordingSettings = self.parent.parent
+            recordingSettings: RecordingSettings = self.parent.parent
 
-        if self.active:
-            self.app.config.set('Experiment', 'iscontinuous', True) 
-            recordingSettings.ids.duration.disabled = True
-            recordingSettings.ids.frames.disabled = True
+            self.app.config.set('Experiment', 'iscontinuous', int(self.active))
+            recordingSettings.ids.duration.disabled = self.active
+            recordingSettings.ids.frames.disabled = self.active
+            
+            self.app.config.write()
 
-        else:
-            self.app.config.set('Experiment', 'iscontinuous', False)
-            recordingSettings.ids.duration.disabled = False
-            recordingSettings.ids.frames.disabled = False
-        
-        self.app.config.write()
+            return True
 
 
 class CameraProperties(GridLayout):
@@ -1990,8 +2000,9 @@ class RecordButton(ImageAcquisitionButton):
         """
 
         # Write coordinate into file.
-        try:
-            self.coordinateFile.write(f"{self.frameCounter} \
+        if not self.coordinateFile.closed:
+            try:
+                self.coordinateFile.write(f"{self.frameCounter} \
 {self.imageTimeStamp} \
 {self.app.coords[0]} \
 {self.app.coords[1]} \
@@ -2004,9 +2015,9 @@ class RecordButton(ImageAcquisitionButton):
 {self.parent.liveAnalysisData.percentile_5} \
 {self.parent.liveAnalysisData.percentile_95} \n")
 
-        #   Handle error from writing the file, such as ValueError: I/O operation on closed file.
-        except ValueError as e:
-            print(f'Error writing coordinateFile: {e}')
+            #   Handle error from writing the file, such as ValueError: I/O operation on closed file.
+            except ValueError as e:
+                print(f'Error writing coordinateFile: {e}')
 
         # Put image(s) into the saving queue
         if not self.isDualColorMode or ( self.isDualColorMode and self.dualColorRecordingMode == 'Original' ):

--- a/glowtracker/GlowTracker.py
+++ b/glowtracker/GlowTracker.py
@@ -3089,6 +3089,7 @@ class RuntimeControls(BoxLayout):
         self.liveFocusThread = None
         self.focus_motion = 0
         self.isTracking = False
+        self.isShowTrackingDialogueFirstTime = True
         self.coord_updateevent: ClockEvent | None = None
         # Center of Mass offset in current tracking frame
         self.cmsOffset_x: float | None = None
@@ -3298,14 +3299,19 @@ class RuntimeControls(BoxLayout):
         camera = app.camera
         stage = app.stage
 
-        if camera is not None and stage is not None and camera.IsGrabbing():
-             # get config values
-            # find an animal and center it once by moving the stage
-            self._popup = WarningPopup(title="Click on animal", text = 'Click on an animal to start tracking it.',
-                            size_hint=(0.5, 0.25))
-            self._popup.open()
-            # make a capture circle - all of this happens in Image Widget, and record offset from center, then dispatch the centering routine
-            #schedule a tracking loop
+        # if camera is not None and stage is not None and camera.IsGrabbing():
+        if True:
+
+            if self.isShowTrackingDialogueFirstTime:
+                self.isShowTrackingDialogueFirstTime = False
+
+                self._popup = WarningPopup(
+                    title="Click on animal", 
+                    text = 'Click on an animal to start tracking it.',
+                    closeTime= 4,
+                    size_hint=(0.5, 0.25)
+                )
+                self._popup.open()
             
         else:
             self._popup = WarningPopup(title="Tracking", text='Tracking requires a stage, a camera and the camera needs to be grabbing.',

--- a/glowtracker/GlowTracker.py
+++ b/glowtracker/GlowTracker.py
@@ -4224,7 +4224,7 @@ class GlowTrackerApp(App):
         config.setdefaults('LedsControl', {
             'mode': 'Off',
             'ledsequencescript': '',
-            'stageprogrammode': 'FourPoint',
+            'stageprogrammode': 'Gaussian',
             'exterior': 'Zero',
             'constanttextinput': 0,
             'p1x': 0,
@@ -4248,6 +4248,7 @@ class GlowTrackerApp(App):
             'g_relative': 'true'
         })
 
+        
         config.setdefaults('Developer', {
             'showfps': 'false'
         })

--- a/glowtracker/GlowTracker.py
+++ b/glowtracker/GlowTracker.py
@@ -1194,11 +1194,13 @@ class LedsStageProgramWidget(BoxLayout):
     g_x_sigma: LedsStageTextInput
     g_y_mean: LedsStageTextInput
     g_y_sigma: LedsStageTextInput
+    g_relative: Switch
     g_amplitude_layout: BoxLayout
     g_x_mean_layout: BoxLayout
     g_x_sigma_layout: BoxLayout
     g_y_mean_layout: BoxLayout
     g_y_sigma_layout: BoxLayout
+    g_relative_layout: BoxLayout
 
     def __init__(self, **kwargs):
         super(LedsStageProgramWidget, self).__init__(**kwargs)
@@ -1215,8 +1217,11 @@ class LedsStageProgramWidget(BoxLayout):
         self.mode = StageProgramMode[self.app.config.get('LedsControl', 'stageprogrammode')]
         self.modeSpinner.text = self.mode.value
         self._popup: Popup = None
+        
         self.fourPointParamWidgets = [self.exterior_layout, self.fourpoint_header_layout, self.p1_layout, self.p2_layout, self.p3_layout, self.p4_layout]
-        self.gaussianPointParamsWidgets = [self.g_amplitude_layout, self.g_x_mean_layout, self.g_x_sigma_layout, self.g_y_mean_layout, self.g_y_sigma_layout]
+        
+        self.gaussianPointParamsWidgets = [self.g_amplitude_layout, self.g_x_mean_layout, self.g_x_sigma_layout, self.g_y_mean_layout, self.g_y_sigma_layout, self.g_relative_layout]
+        
         self.initModeWidget()
         self.updateLedStageProgram()
 
@@ -1319,13 +1324,40 @@ class LedsStageProgramWidget(BoxLayout):
             )
 
             # Update DAQStageProgram variables
-            self.app.daqControl.daqStageProgram.update(mode= self.mode, gaussianParams= gaussianParams)
+            self.app.daqControl.daqStageProgram.update(mode= self.mode, gaussianParams= gaussianParams, isGaussianRelative= self.g_relative.active)
 
         # Generate value map plot
         valMapPlot = self.app.daqControl.daqStageProgram.generateValueMapPlot()
         
         # Show the plot
         self.ids.visualizationplot.texture = imageToTexture(valMapPlot)
+
+
+class GaussianRelativePositionSwitch(Switch):
+    configKey = StringProperty()
+    root = ObjectProperty()     # Reference to root, which should be LedsStageProgramWidget
+
+    def on_kv_post(self, *args):
+        self.app = App.get_running_app()
+        self.active = self.app.config.getboolean('LedsControl', self.configKey)
+
+    
+    @override
+    def on_touch_up(self, touch): 
+        """On switch touch up callback. Update the config value 'self.configKey',
+            and call root.updateLedStageProgram()
+
+        Args:
+            touch (Touch): touch input data.
+        """
+        if super(GaussianRelativePositionSwitch, self).on_touch_up(touch):
+
+            self.app.config.set('LedsControl', self.configKey, int(self.active))
+            self.app.config.write()
+
+            self.root.updateLedStageProgram()
+
+            return True
     
 
 class LedsStageTextInput(TextInput):
@@ -4198,7 +4230,8 @@ class GlowTrackerApp(App):
             'g_x_mean': 0,
             'g_x_sigma': 0,
             'g_y_mean': 0,
-            'g_y_sigma': 0
+            'g_y_sigma': 0,
+            'g_relative': 'true'
         })
 
         config.setdefaults('Developer', {

--- a/glowtracker/GlowTracker.py
+++ b/glowtracker/GlowTracker.py
@@ -1938,9 +1938,9 @@ class LiveViewButton(ImageAcquisitionButton):
     @override
     def acquisitionCondition(self) -> bool:
 
-        return self.camera is not None \
+        return (self.camera is not None) \
             and (self.camera.IsGrabbing() or self.camera.isOnHold()) \
-            and self.state == 'down'
+            and (self.state == 'down')
 
 
 class RecordButton(ImageAcquisitionButton):
@@ -2218,9 +2218,9 @@ class RecordButton(ImageAcquisitionButton):
     @override
     def acquisitionCondition(self) -> bool:
 
-        return self.camera is not None \
+        return (self.camera is not None) \
             and (self.camera.IsGrabbing() or self.camera.isOnHold()) \
-            and self.isContinuous or (self.frameCounter < self.numberRecordframes) \
+            and (self.isContinuous or (self.frameCounter < self.numberRecordframes)) \
             and self.state == 'down'
 
     

--- a/glowtracker/GlowTracker.py
+++ b/glowtracker/GlowTracker.py
@@ -974,7 +974,6 @@ class LedsControlWidget(BoxLayout):
         # Attributes
         self.ledsScriptFile: str = self.ids.ledsscriptfile.text
         self.ledsScript: str = ''
-        self.ledsSequnceDict: dict = dict()
         self._popup: Popup = None
 
         # Initialize MacroScriptExecutor
@@ -1378,6 +1377,10 @@ class ImageAcquisitionButton(ToggleButton):
 
         # Set self button state to normal
         self.state = 'normal'
+
+        # Reset the DAQ state
+        if self.app.daqControl is not None and self.app.daqControl.isEnable:
+            self.app.daqControl.reset()
     
 
     def imageAcquisitionLoopingThread(self, grabArgs) -> None:
@@ -1399,14 +1402,20 @@ class ImageAcquisitionButton(ToggleButton):
             self.camera.StartGrabbingMax(grabArgs.numberOfImagesToGrab, grabArgs.grabStrategy)
             
         fps = self.camera.ResultingFrameRate()
-        print("Grabbing Framerate:", fps)
+        print(f'Grabbing Framerate: {fps:.3f} fps')
 
         # Schedule a display update
         fps = self.app.config.getfloat('Camera', 'display_fps')
         self.updateDisplayImageEvent = Clock.schedule_interval(self.updateDisplayImage, 1.0 /fps)
-        print(f'Displaying at {fps} fps')
+        print(f'Displaying at {fps:.3f} fps')
 
         returnCameraOnHoldFlag = True if self.camera.isOnHold() else False
+
+        # Register start acquisition time
+        imageAcquisitionManager: ImageAcquisitionManager = self.parent
+        imageAcquisitionManager.startTime = time.perf_counter()
+        if self.app.daqControl is not None and self.app.daqControl.isEnable:
+            self.app.daqControl.start()
 
         # Start image acquisition loop
         while self.acquisitionCondition():
@@ -1550,18 +1559,23 @@ class ImageAcquisitionButton(ToggleButton):
         """    
 
         # Update parent (ImageAcquisitionManager) images
-        self.parent.image = self.image
-        self.parent.imageTimeStamp = self.imageTimeStamp
-        self.parent.imageRetrieveTimeStamp = self.imageRetrieveTimeStamp
-        self.parent.dualColorMainSideImage = self.dualColorMainSideImage
+        imageAcquisitionManager: ImageAcquisitionManager = self.parent
+        imageAcquisitionManager.image = self.image
+        imageAcquisitionManager.imageTimeStamp = self.imageTimeStamp
+        imageAcquisitionManager.imageRetrieveTimeStamp = self.imageRetrieveTimeStamp
+        imageAcquisitionManager.dualColorMainSideImage = self.dualColorMainSideImage
+        imageAcquisitionManager.currentTime = time.perf_counter()
+        
         # Update display frame value
         self.runtimeControls.framecounter.value += 1
+
         # Update live analysis data
-        self.app.root.ids.middlecolumn.ids.liveanalysislabel.updateText(self.parent.liveAnalysisData)
+        self.app.root.ids.middlecolumn.ids.liveanalysislabel.updateText(imageAcquisitionManager.liveAnalysisData)
 
         # Trigger DAQ Control command
-        # Actually, is framecounter.value affected when frame skip?
-        self.app.daqControl.triggerCommand(self.runtimeControls.framecounter.value)
+        # Actually, is framecounter.value effected when frame skip?
+        if self.app.daqControl is not None:
+            self.app.daqControl.triggerCommand(frameNum= self.runtimeControls.framecounter.value, frameTime= imageAcquisitionManager.currentTime - imageAcquisitionManager.startTime)
 
 
     def finishAcquisitionCallback(self) -> None:
@@ -2023,6 +2037,8 @@ class ImageAcquisitionManager(BoxLayout):
     imageRetrieveTimeStamp: float = 0
     dualColorMainSideImage: np.ndarray = np.zeros((1,1))
     liveAnalysisData: LiveAnalysisData = LiveAnalysisData()
+    startTime: float = 0
+    currentTime: float = 0
 
 
     def __init__(self,  **kwargs):

--- a/glowtracker/GlowTracker.py
+++ b/glowtracker/GlowTracker.py
@@ -1187,8 +1187,9 @@ class LedsStageProgramWidget(BoxLayout):
         self.stage = self.app.stage
         self.camera = self.app.camera
         self.imageAcquisitionManager: ImageAcquisitionManager = self.app.root.ids.middlecolumn.ids.runtimecontrols.imageacquisitionmanager
-        self.exterior = macro.Exterior.Zero
-        self.mode = StageProgramMode.FourPoint
+        self.exterior = macro.Exterior[self.app.config.get('LedsControl', 'exterior')]
+        self.mode = StageProgramMode[self.app.config.get('LedsControl', 'stageprogrammode')]
+        self.modeSpinner.text = self.mode.value
         self._popup: Popup = None
         self.fourPointParamWidgets = [self.exterior_layout, self.fourpoint_header_layout, self.p1_layout, self.p2_layout, self.p3_layout, self.p4_layout]
         self.gaussianPointParamsWidgets = [self.g_amplitude_layout, self.g_x_mean_layout, self.g_x_sigma_layout, self.g_y_mean_layout, self.g_y_sigma_layout]

--- a/glowtracker/GlowTracker.py
+++ b/glowtracker/GlowTracker.py
@@ -1225,6 +1225,9 @@ class LedsStageProgramWidget(BoxLayout):
         self.fourPointParamWidgets = [self.exterior_layout, self.fourpoint_header_layout, self.p1_layout, self.p2_layout, self.p3_layout, self.p4_layout, self.relative_layout]
         
         self.gaussianPointParamsWidgets = [self.g_amplitude_layout, self.g_x_mean_layout, self.g_x_sigma_layout, self.g_y_mean_layout, self.g_y_sigma_layout, self.g_relative_layout]
+
+        # Temporary containing to keep the removed widget alive
+        self._tempContainer = BoxLayout()
         
         self.initModeWidget()
         self.updateLedStageProgram()
@@ -1248,11 +1251,13 @@ class LedsStageProgramWidget(BoxLayout):
             # Remove Gaussian params widgets
             for widget in self.gaussianPointParamsWidgets:
                 stacklayout.remove_widget(widget= widget)
+                self._tempContainer.add_widget(widget= widget)
             
         elif self.mode == StageProgramMode.Gaussian:
             # Remove FourPoint params widgets
             for widget in self.fourPointParamWidgets:
                 stacklayout.remove_widget(widget= widget)
+                self._tempContainer.add_widget(widget= widget)
         
 
     def updateExteriorChoice(self) -> None:
@@ -1283,9 +1288,11 @@ class LedsStageProgramWidget(BoxLayout):
                 # Remove Gaussian params widgets
                 for widget in self.gaussianPointParamsWidgets:
                     stacklayout.remove_widget(widget= widget)
-                
+                    self._tempContainer.add_widget(widget= widget)
+
                 # Add FourPoint params widgets
                 for widget in self.fourPointParamWidgets:
+                    self._tempContainer.remove_widget(widget= widget)
                     stacklayout.add_widget(widget= widget)
 
             elif self.mode == StageProgramMode.Gaussian:
@@ -1293,9 +1300,11 @@ class LedsStageProgramWidget(BoxLayout):
                 # Remove FourPoint params widgets
                 for widget in self.fourPointParamWidgets:
                     stacklayout.remove_widget(widget= widget)
+                    self._tempContainer.add_widget(widget= widget)
                 
                 # Add Gaussian params widgets
                 for widget in self.gaussianPointParamsWidgets:
+                    self._tempContainer.remove_widget(widget= widget)
                     stacklayout.add_widget(widget= widget)
         
         # Save to config

--- a/glowtracker/GlowTracker.py
+++ b/glowtracker/GlowTracker.py
@@ -1131,6 +1131,7 @@ class LedsStageProgramWidget(BoxLayout):
         self.imageAcquisitionManager: ImageAcquisitionManager = self.app.root.ids.middlecolumn.ids.runtimecontrols.imageacquisitionmanager
         self.exterior = macro.Exterior.Zero
         self._popup: Popup = None
+        self.updateLedStageProgram()
 
     
     def setCloseCallback( self, closeCallback: callable ) -> None:
@@ -1148,15 +1149,13 @@ class LedsStageProgramWidget(BoxLayout):
         if self.exteriorSpinner.text == 'Constant':
             self.exterior = macro.Exterior.Constant
             
-        elif self.exteriorSpinner.text == 'Zero':
+        else:
             self.exterior = macro.Exterior.Zero
             
-        else:
-            self.exterior = macro.Exterior.Nearest
-
         # Enable constanttextinput if choice is Constant
         if self.exterior == macro.Exterior.Constant:
             self.constanttextinput.disabled = False
+
         else:
             self.constanttextinput.disabled = True
         
@@ -1186,14 +1185,10 @@ class LedsStageProgramWidget(BoxLayout):
         vertices = [p1, p2, p3, p4]
         center = (p1.point + p2.point + p3.point + p4.point) / 4
         vertices.sort(key= lambda vertex: math.atan2(vertex.point[1] - center[1], vertex.point[0] - center[0]))
-        # Now the points are sorted in this order:
-        #   btmLeft = points[0]
-        #   btmRight = points[1]
-        #   topLeft = points[3]
-        #   topRight = points[2]
+        # Now the points are sorted in anti-clockwise order starting from btmLeft: btmLeft ,btmRight ,topRight ,topRight
         
         # Compute value map
-        valMap = np.zeros([160 + 1, 160 + 1], np.float32)
+        valMap = np.zeros([160 + 1, 160 + 1, 1], np.float32)
         for y in range(valMap.shape[0]):
             for x in range(valMap.shape[1]):
 
@@ -1218,7 +1213,8 @@ class LedsStageProgramWidget(BoxLayout):
         fig = plt.figure(figsize=(6, 6))
         
         # Plot map
-        plt.imshow(map, vmin= np.min(map), vmax= np.max(map), cmap= 'magma')
+        im = plt.imshow(map, cmap= 'magma')
+        plt.colorbar(im)
         
         # Plot 4 points
         def drawPointWithAnnotation(point: List[float], color: str, name: str) -> None:
@@ -1239,7 +1235,6 @@ class LedsStageProgramWidget(BoxLayout):
 
         # Add grid and legend
         plt.grid(True)
-        plt.legend()
 
         # Render the plot to a numpy array
         canvas = FigureCanvasAgg(fig)

--- a/glowtracker/GlowTracker.py
+++ b/glowtracker/GlowTracker.py
@@ -1184,7 +1184,8 @@ class LedsStageProgramWidget(BoxLayout):
 
         # Sort points by its angle
         vertices = [p1, p2, p3, p4]
-        vertices.sort(key= lambda vertex: math.atan2(vertex.point[1], vertex.point[0]))
+        center = (p1.point + p2.point + p3.point + p4.point) / 4
+        vertices.sort(key= lambda vertex: math.atan2(vertex.point[1] - center[1], vertex.point[0] - center[0]))
         # Now the points are sorted in this order:
         #   btmLeft = points[0]
         #   btmRight = points[1]
@@ -1199,7 +1200,7 @@ class LedsStageProgramWidget(BoxLayout):
                 val = Vertex2D.bilerp(vertices[0], vertices[1], vertices[2], vertices[3], np.array([x, y], np.float32), self.exterior, exteriorConstant)
 
                 # Clamp between 0, 5 vol
-                val = min(max(0, x), 5)
+                val = min(max(0, val), 5)
                 
                 valMap[y, x] = val
 
@@ -1217,7 +1218,7 @@ class LedsStageProgramWidget(BoxLayout):
         fig = plt.figure(figsize=(6, 6))
         
         # Plot map
-        plt.imshow(map, vmin= np.min(map), vmax= np.max(map))
+        plt.imshow(map, vmin= np.min(map), vmax= np.max(map), cmap= 'magma')
         
         # Plot 4 points
         def drawPointWithAnnotation(point: List[float], color: str, name: str) -> None:

--- a/glowtracker/GlowTracker.py
+++ b/glowtracker/GlowTracker.py
@@ -1068,7 +1068,7 @@ class LedsControlWidget(BoxLayout):
         self.ids.scripttext.text = self.ledsScript
 
         # Set as recent script
-        self.app.config.set('LedsControl', 'recentscript', self.ledsScriptFile)
+        self.app.config.set('LedsControl', 'ledsequencescript', self.ledsScriptFile)
         self.app.config.write()
 
         # Parse text to command
@@ -1096,7 +1096,7 @@ class LedsControlWidget(BoxLayout):
                 file.write(script)
 
             # Set as recent script
-            self.app.config.set('LedsControl', 'recentscript', self.ids.ledsscriptfile.text)
+            self.app.config.set('LedsControl', 'ledsequencescript', self.ids.ledsscriptfile.text)
 
             print(f"Saved the script {file_path}")
 
@@ -3774,7 +3774,7 @@ class Connections(BoxLayout):
 
         # Load recent script
         try:
-            recentScriptFile = app.config.get('LedsControl', 'recentscript')
+            recentScriptFile = app.config.get('LedsControl', 'ledsequencescript')
             # Read the file
             with open(recentScriptFile, 'r') as file:
                 recentScript = file.read()
@@ -3997,7 +3997,7 @@ class GlowTrackerApp(App):
         })
 
         config.setdefaults('LedsControl', {
-            'recentscript': '',
+            'ledsequencescript': '',
             'isenablesequencer': 'false',
             'isenablestageprogram': 'false',
             'exterior': 'Zero',

--- a/glowtracker/GlowTracker.py
+++ b/glowtracker/GlowTracker.py
@@ -182,28 +182,30 @@ class LeftColumn(BoxLayout):
 
     def _do_setup(self, *l):
         self.savefile = self.app.config.get("Experiment", "exppath")
-        self.path_validate()
+        self.createRecordingPath()
         self.cameraConfigFile = self.app.config.get('Camera', 'default_settings')
         self.apply_cam_settings()
 
 
-    def path_validate(self):
-        p = Path(self.saveloc.text)
-        if p.exists() and p.is_dir():
-            self.app.config.set("Experiment", "exppath", self.saveloc.text)
-            self.app.config.write()
-        # check if the parent dir exists, then create the folder
-        elif p.parent.exists():
-            p.mkdir(mode=0o777, parents=False, exist_ok=True)
-        else:
-            self.saveloc.text = self.savefile
-        self.app.config.set("Experiment", "exppath", self.saveloc.text)
+    def createRecordingPath(self) -> None:
+
+        relativePath = self.saveloc.text
+        absPath = os.path.abspath(relativePath)
+
+        # Create the path if not yet exists
+        if not os.path.exists(absPath) or not os.path.isdir(absPath):
+            os.makedirs(name= absPath, mode=777, exist_ok= True)
+
+        # Save to config
+        self.app.config.set("Experiment", "exppath", absPath)
         self.app.config.write()
-        self.savefile = self.app.config.get("Experiment", "exppath")
+
+        self.savefile = absPath
+        print(f'Set recording path to {self.savefile}')
+        
         # reset the stage keys
         self.app.bind_keys()
-        print('saving path changed')
-
+    
 
     def dismiss_popup(self):
         self.app.bind_keys()
@@ -241,7 +243,7 @@ class LeftColumn(BoxLayout):
     def save(self, path, filename):
         self.savefile = os.path.join(path, filename)
         self.saveloc.text = (self.savefile)
-        self.path_validate()
+        self.createRecordingPath()
         self.dismiss_popup()
 
 
@@ -1974,8 +1976,8 @@ class RecordButton(ImageAcquisitionButton):
         self.dualColorRecordingMode: str = ''
         self.imageFilenameFormat: str = ''
         self.imageFilenameExtension: str = ''
-        self.prevLiveViewButtonState: str = ''
-        self.prevLiveAnalysisButtonState: str = ''
+        self.prevLiveViewButtonState: str = 'normal'
+        self.prevLiveAnalysisButtonState: str = 'normal'
         
 
     @override
@@ -2014,17 +2016,25 @@ class RecordButton(ImageAcquisitionButton):
         self.camera = self.app.camera
         self.runtimeControls = App.get_running_app().root.ids.middlecolumn.runtimecontrols
 
+        self.saveFilePath = self.app.root.ids.leftcolumn.savefile
+
+        # Store relevent states in case needs to turn back
+        imageAcquisitionManager: ImageAcquisitionManager = self.parent
+        self.prevLiveViewButtonState = imageAcquisitionManager.liveviewbutton.state
+
+        # If there is no camera or recording file path doesn't exists
         if self.camera is None:
             self.state = 'normal'
             return
-
-        # Store relevent states
-        imageAcquisitionManager: ImageAcquisitionManager = self.parent
         
+        if not os.path.exists(self.saveFilePath):
+            print("The recording path doesn't exist. Can't start recording.")
+            self.state = 'normal'
+            return
+
         # Stop camera if already running and disable the LiveView button
         # If the camera is already running it in live view button,
         #   put the transition "OnHold" flag, and restart camera in Recording mode
-        self.prevLiveViewButtonState = imageAcquisitionManager.liveviewbutton.state
 
         if self.prevLiveViewButtonState == 'down':
             self.camera.setIsOnHold(True)
@@ -2035,7 +2045,6 @@ class RecordButton(ImageAcquisitionButton):
 
         self.runtimeControls.framecounter.value = 0
 
-        self.saveFilePath = self.app.root.ids.leftcolumn.savefile
         self.isDualColorMode = self.app.config.getboolean('DualColor', 'dualcolormode')
         self.dualColorRecordingMode = self.app.config.get('DualColor', 'recordingmode')
 
@@ -2181,7 +2190,7 @@ class RecordButton(ImageAcquisitionButton):
             - Un-disabled (enable if) the LiveView button
         """        
 
-        if self.camera is None:
+        if self.camera is None or self.frameCounter == 0:
             return
         
         # If the live view button was previously running, 
@@ -2189,7 +2198,10 @@ class RecordButton(ImageAcquisitionButton):
         if self.prevLiveViewButtonState == 'down':
             self.camera.setIsOnHold(True)
 
-        print(f'Recorded {self.runtimeControls.framecounter.value} frames')
+        print(f'Recorded {self.frameCounter} frames')
+
+        # Reset frame counter
+        self.frameCounter = 0
 
         # Stop the camera and clear values
         super().stopImageAcquisition()

--- a/glowtracker/GlowTracker.py
+++ b/glowtracker/GlowTracker.py
@@ -194,7 +194,7 @@ class LeftColumn(BoxLayout):
 
         # Create the path if not yet exists
         if not os.path.exists(absPath) or not os.path.isdir(absPath):
-            os.makedirs(name= absPath, mode=777, exist_ok= True)
+            os.makedirs(name= absPath, mode=0o777, exist_ok= True)
 
         # Save to config
         self.app.config.set("Experiment", "exppath", absPath)
@@ -396,7 +396,8 @@ class RightColumn(BoxLayout):
         camera = self.app.camera
         stage: Stage = self.app.stage
 
-        if camera is not None and stage is not None:
+        if True:
+        # if camera is not None and stage is not None:
             # Create the calibration widget
             calibrationTabPanel = CalibrationTabPanel()
             calibrationTabPanel.setCloseCallback(closeCallback= self.dismiss_popup)

--- a/glowtracker/GlowTracker.py
+++ b/glowtracker/GlowTracker.py
@@ -1138,7 +1138,8 @@ class LedsControlWidget(BoxLayout):
         """Save the current macro script into the same file (overwrite if exists).
         """
         file_path = self.ids.ledsscriptfile.text
-        script = self.ids.scripttext.text
+        # Copy text from inputtext to self
+        self.ledsScript = self.ids.scripttext.text
 
         try:
             # Convert to absolute path if it's a relative path
@@ -1151,7 +1152,7 @@ class LedsControlWidget(BoxLayout):
             
             # Open the file in overwrite mode, creating it if it doesn't exist
             with open(abs_file_path, 'w') as file:
-                file.write(script)
+                file.write(self.ledsScript)
 
             # Set as recent script
             self.app.config.set('LedsControl', 'ledsequencescript', self.ids.ledsscriptfile.text)
@@ -1163,6 +1164,16 @@ class LedsControlWidget(BoxLayout):
 
         except Exception as e:
             print(f"Error saving LED script: {e}")
+
+        # Then update the current script to daqControl
+        if self.app.daqControl is not None:
+            
+            try:
+                self.app.daqControl.parseTextScript(self.ledsScript)
+
+            except Exception as e:
+                print(e)
+                return None
     
 
 class LedsStageProgramWidget(BoxLayout):

--- a/glowtracker/GlowTracker.py
+++ b/glowtracker/GlowTracker.py
@@ -1377,10 +1377,6 @@ class ImageAcquisitionButton(ToggleButton):
 
         # Set self button state to normal
         self.state = 'normal'
-
-        # Reset the DAQ state
-        if self.app.daqControl is not None and self.app.daqControl.isEnable:
-            self.app.daqControl.reset()
     
 
     def imageAcquisitionLoopingThread(self, grabArgs) -> None:
@@ -1414,8 +1410,6 @@ class ImageAcquisitionButton(ToggleButton):
         # Register start acquisition time
         imageAcquisitionManager: ImageAcquisitionManager = self.parent
         imageAcquisitionManager.startTime = time.perf_counter()
-        if self.app.daqControl is not None and self.app.daqControl.isEnable:
-            self.app.daqControl.start()
 
         # Start image acquisition loop
         while self.acquisitionCondition():
@@ -1572,18 +1566,11 @@ class ImageAcquisitionButton(ToggleButton):
         # Update live analysis data
         self.app.root.ids.middlecolumn.ids.liveanalysislabel.updateText(imageAcquisitionManager.liveAnalysisData)
 
-        # Trigger DAQ Control command
-        # Actually, is framecounter.value effected when frame skip?
-        if self.app.daqControl is not None:
-            self.app.daqControl.triggerCommand(frameNum= self.runtimeControls.framecounter.value, frameTime= imageAcquisitionManager.currentTime - imageAcquisitionManager.startTime)
-
 
     def finishAcquisitionCallback(self) -> None:
         """Finished the acquisition looping callback. Needs to be overridden.
         """        
-        # Reset the DAQ state
-        if self.app.daqControl is not None:
-            self.app.daqControl.reset()
+        pass
 
 
     def updateDisplayImage(self, dt) -> None:
@@ -1722,6 +1709,10 @@ class RecordButton(ImageAcquisitionButton):
         # Start a thread for saving images
         self.savingthread = Thread(target= macro.ImageSaver.startSavingImageInQueueThread, args= [self.imageQueue, 3])
         self.savingthread.start()
+
+        # Prep DAQ control
+        if self.app.daqControl is not None and self.app.daqControl.isEnable:
+            self.app.daqControl.start()
 
         # Setup image acquisition thread parameters
         self.initRecordingParams()
@@ -1890,6 +1881,10 @@ class RecordButton(ImageAcquisitionButton):
             self.parent.liveviewbutton.state = self.prevLiveViewButtonState
         
         Clock.schedule_once( resumeButtonsState )
+
+        # Reset the DAQ state
+        if self.app.daqControl is not None and self.app.daqControl.isEnable:
+            self.app.daqControl.reset()
     
 
     @override
@@ -1984,6 +1979,15 @@ class RecordButton(ImageAcquisitionButton):
                 
             self.camera.setIsOnHold(True)
 
+
+        # Trigger DAQ Control command
+        # Actually, is framecounter.value effected when frame skip?
+        if self.app.daqControl is not None and self.app.daqControl.isEnable:
+
+            imageAcquisitionManager: ImageAcquisitionManager = self.parent
+
+            self.app.daqControl.triggerCommand(frameNum= self.runtimeControls.framecounter.value, frameTime= imageAcquisitionManager.currentTime - imageAcquisitionManager.startTime)
+
         super().receiveImageCallback()
     
 
@@ -1995,6 +1999,10 @@ class RecordButton(ImageAcquisitionButton):
         self.imageQueue.put(None)
 
         print(f'Recorded {self.numberRecordframes} frames.')
+
+        # Reset the DAQ state
+        if self.app.daqControl is not None and self.app.daqControl.isEnable:
+            self.app.daqControl.reset()
 
         # Call to recording-stopping procedure
         self.stopImageAcquisition()
@@ -3525,10 +3533,25 @@ class Connections(BoxLayout):
         # Connect to device
         app.daqControl = DAQControl.createAndConnectDaq()
         
+        # If no device
         if app.daqControl is None:
             self.daq_connection.state = 'normal'
+            return
         
         app.daqControl.isEnable = app.config.getboolean("LedsControl", "isenable")
+
+        # Load recent script
+        try:
+            recentScriptFile = app.config.get('LedsControl', 'recentscript')
+            # Read the file
+            with open(recentScriptFile, 'r') as file:
+                recentScript = file.read()
+                # Parse the script
+                app.daqControl.parseTextScript(recentScript)
+                print(f'Loaded LEDs control script {recentScriptFile}')
+
+        except Exception as e:
+            print(f'Loading recent LEDs control script: {e}')
 
 
     def disconnectDaq(self):

--- a/glowtracker/GlowTracker.py
+++ b/glowtracker/GlowTracker.py
@@ -3711,6 +3711,33 @@ class Connections(BoxLayout):
         except Exception as e:
             print(f'Loading recent LEDs control script: {e}')
 
+        # Load StageProgram properties
+        stageprogrammode = StageProgramMode[app.config.get('LedsControl', 'stageprogrammode')]
+        exterior = macro.Exterior[app.config.get('LedsControl', 'exterior')]
+        exteriorConstant = app.config.getfloat('LedsControl', 'constanttextinput')
+        p1x = app.config.getfloat('LedsControl', 'p1x')
+        p1y = app.config.getfloat('LedsControl', 'p1y')
+        p1v = app.config.getfloat('LedsControl', 'p1v')
+        p2x = app.config.getfloat('LedsControl', 'p2x')
+        p2y = app.config.getfloat('LedsControl', 'p2y')
+        p2v = app.config.getfloat('LedsControl', 'p2v')
+        p3x = app.config.getfloat('LedsControl', 'p3x')
+        p3y = app.config.getfloat('LedsControl', 'p3y')
+        p3v = app.config.getfloat('LedsControl', 'p3v')
+        p4x = app.config.getfloat('LedsControl', 'p4x')
+        p4y = app.config.getfloat('LedsControl', 'p4y')
+        p4v = app.config.getfloat('LedsControl', 'p4v')
+
+        p1 = Vertex2D(np.array([p1x, p1y], np.float32), p1v, 'P1')
+        p2 = Vertex2D(np.array([p2x, p2y], np.float32), p2v, 'P2')
+        p3 = Vertex2D(np.array([p3x, p3y], np.float32), p3v, 'P3')
+        p4 = Vertex2D(np.array([p4x, p4y], np.float32), p4v, 'P4')
+
+        quadVertex = [p1, p2, p3, p4]
+
+        # Update DAQStageProgram variables
+        app.daqControl.daqStageProgram.update(mode= stageprogrammode, quadVertex= quadVertex, exterior= exterior, exteriorConstant= exteriorConstant)
+
 
     def disconnectDaq(self):
         print('Disconnecting DAQ')

--- a/glowtracker/GlowTracker.py
+++ b/glowtracker/GlowTracker.py
@@ -71,8 +71,6 @@ import shutil
 from pyparsing import ParseException
 import matplotlib.pyplot as plt
 from dataclasses import dataclass
-import re
-import u3
 
 
 # 
@@ -83,6 +81,7 @@ import Microscope_macros as macro
 import Basler_control as basler
 from MacroScript import MacroScriptExecutor
 from AutoFocus import AutoFocusPID, FocusEstimationMethod
+from DAQ_control import DAQControl
 
 # 
 # Math
@@ -1047,23 +1046,9 @@ class LedsControlWidget(BoxLayout):
         self.app.config.set('LedsControl', 'recentscript', self.ledsScriptFile)
         self.app.config.write()
 
-        # Parse text to dict
-        try:
-            
-            # Remove empty lines and surrounding whitespace
-            lines = [line.strip() for line in self.ledsScript.splitlines() if line.strip()]
-
-            # Remove trailing commas from each line
-            lines = [re.sub(r',$', '', line) for line in lines]
-
-            # Wrap into a dict literal
-            preprocessdText = "{\n" + ",\n".join(lines) + "\n}"
-            
-            # Parse the text to be a dict object. Highlight keywords "on", "off"
-            self.ledsSequnceDict = eval(preprocessdText, globals= {"on": "on", "off": "off"})
-            
-        except Exception as e:
-            raise ValueError(f"Failed to parse input text: {e}") from None
+        # Parse text to command
+        if self.app.daqControl is not None:
+            self.app.daqControl.parseTextScript(self.ledsScript)
         
 
     def saveScript(self):
@@ -1094,7 +1079,7 @@ class LedsControlWidget(BoxLayout):
             print(f"Error saving to {file_path}: {e}")
 
         except Exception as e:
-            print(f"Error saving macro script: {e}")
+            print(f"Error saving LED script: {e}")
     
 
 class StageAxisController(BoxLayout):
@@ -1550,6 +1535,10 @@ class ImageAcquisitionButton(ToggleButton):
         self.runtimeControls.framecounter.value += 1
         # Update live analysis data
         self.app.root.ids.middlecolumn.ids.liveanalysislabel.updateText(self.parent.liveAnalysisData)
+
+        # Trigger DAQ Control command
+        # Actually, is framecounter.value affected when frame skip?
+        self.app.daqControl.triggerCommand(self.runtimeControls.framecounter.value)
 
 
     def finishAcquisitionCallback(self) -> None:
@@ -3404,8 +3393,11 @@ class Connections(BoxLayout):
 
 
     def _do_setup(self, *l):
+        """Try connecting to all devices
+        """
         self.stage_connection.state = 'down'
         self.cam_connection.state = 'down'
+        self.daq_connection.state = 'down'
 
 
     def connectCamera(self):
@@ -3485,35 +3477,24 @@ class Connections(BoxLayout):
         app.root.ids.leftcolumn.ids.zcontrols.disable_all()
     
 
-    def connectDac(self):
-        print('Connecting DAC')
+    def connectDaq(self):
+        print('Connecting DAQ')
         app: GlowTrackerApp = App.get_running_app()
 
         # Connect to device
-        try:
-            device = u3.U3(debug= False)
-
-        except Exception as e:
-            print(e)
-            self.dac_connection.state = 'normal'
-
-        else:
-            print(f"Using {device.deviceName}, serial: {device.serialNumber}")
-            # Set to factory default
-            device.setDefaults()
-            # Calibrate
-            device.getCalibrationData()
-            # Save to App's attr
-            app.dac = device
+        app.daqControl = DAQControl.createAndConnectDaq()
+        
+        if app.daqControl is None:
+            self.daq_connection.state = 'normal'
 
 
-    def disconnectDac(self):
-        print('Disconnecting DAC')
+    def disconnectDaq(self):
+        print('Disconnecting DAQ')
         app: GlowTrackerApp = App.get_running_app()
 
-        if app.dac is not None:
-            app.dac.close()
-            app.dac = None
+        if app.daqControl is not None:
+            app.daqControl.close()
+            app.daqControl = None
 
 
 class MyCounter():
@@ -3582,7 +3563,7 @@ class GlowTrackerApp(App):
         # hardware
         self.camera: basler.Camera | None = None
         self.stage: Stage = Stage(None)
-        self.dac: u3.U3 | None = None
+        self.daqControl: DAQControl | None = None
         self.updateFpsEvent = None
     
 
@@ -4234,6 +4215,10 @@ class GlowTrackerApp(App):
         if self.camera is not None:
             print('Disconnecting Camera')
             self.camera.Close()
+        
+        if self.daqControl is not None:
+            print('Disconnecting DAQ')
+            self.daqControl.close()
 
         # stop the app
         self.stop()

--- a/glowtracker/GlowTracker.py
+++ b/glowtracker/GlowTracker.py
@@ -1579,6 +1579,8 @@ class LiveAnalysisData():
     skewness: float = 0
     percentile_5: float = 0
     percentile_95: float = 0
+    # We need a locking mechanism here to manage race-condition of modifying LiveAnalysisData from both MainThread and SubThread e.g. when Main want to reset values while subthread is still computing them.
+    lock: Lock = Lock()
 
 
 class ImageAcquisitionButton(ToggleButton):
@@ -1642,6 +1644,7 @@ class ImageAcquisitionButton(ToggleButton):
             - Stop the update display event.
             - Stop camera grabbing.
             - Stop the acquisition looping thread if not already.
+            - Reset GUI back 
         """        
         if self.camera is None:
             return
@@ -1664,6 +1667,17 @@ class ImageAcquisitionButton(ToggleButton):
 
         # Set self button state to normal.
         self.state = 'normal'
+
+        # Reset liveAnalysisData
+        liveAnalysisData: LiveAnalysisData = self.runtimeControls.imageacquisitionmanager.liveAnalysisData
+        with liveAnalysisData.lock:
+            liveAnalysisData.minBrightness = 0
+            liveAnalysisData.maxBrightness = 0
+            liveAnalysisData.meanBrightness = 0
+            liveAnalysisData.medianBrightness = 0
+            liveAnalysisData.skewness = 0
+            liveAnalysisData.percentile_5 = 0
+            liveAnalysisData.percentile_95 = 0
     
 
     def imageAcquisitionLoopingThread(self, grabArgs) -> None:
@@ -1822,15 +1836,17 @@ class ImageAcquisitionButton(ToggleButton):
             # Crop to tracking region
             image = macro.cropCenterImage(image, capture_radius * 2, capture_radius * 2)
 
-        imageAcquisitionManager: ImageAcquisitionManager = self.parent
         # Do we need to crop on tracking region? 
-        imageAcquisitionManager.liveAnalysisData.minBrightness = np.min(image, axis= None)
-        imageAcquisitionManager.liveAnalysisData.maxBrightness = np.max(image, axis= None)
-        imageAcquisitionManager.liveAnalysisData.meanBrightness = np.mean(image, axis= None)
-        imageAcquisitionManager.liveAnalysisData.medianBrightness = np.median(image, axis= None)
-        imageAcquisitionManager.liveAnalysisData.skewness = skew(image, axis= None, nan_policy= 'omit')
-        imageAcquisitionManager.liveAnalysisData.percentile_5 = np.percentile(image, q= 5, axis= None)
-        imageAcquisitionManager.liveAnalysisData.percentile_95 = np.percentile(image, q= 95, axis= None)
+        imageAcquisitionManager: ImageAcquisitionManager = self.parent
+        liveAnalysisData = imageAcquisitionManager.liveAnalysisData
+        with liveAnalysisData.lock:
+            imageAcquisitionManager.liveAnalysisData.minBrightness = np.min(image, axis= None)
+            imageAcquisitionManager.liveAnalysisData.maxBrightness = np.max(image, axis= None)
+            imageAcquisitionManager.liveAnalysisData.meanBrightness = np.mean(image, axis= None)
+            imageAcquisitionManager.liveAnalysisData.medianBrightness = np.median(image, axis= None)
+            imageAcquisitionManager.liveAnalysisData.skewness = skew(image, axis= None, nan_policy= 'omit')
+            imageAcquisitionManager.liveAnalysisData.percentile_5 = np.percentile(image, q= 5, axis= None)
+            imageAcquisitionManager.liveAnalysisData.percentile_95 = np.percentile(image, q= 95, axis= None)
     
 
     def receiveImageCallback(self) -> None:
@@ -1916,7 +1932,7 @@ class LiveViewButton(ImageAcquisitionButton):
 
         super().stopImageAcquisition()
 
-        print('Stop live view')
+        print('Stop Live view')
 
 
     @override
@@ -2232,7 +2248,8 @@ class RecordButton(ImageAcquisitionButton):
         # Write coordinate into file.
         if not self.coordinateFile.closed:
             try:
-                self.coordinateFile.write(f"{self.frameCounter} \
+                with self.parent.liveAnalysisData.lock:
+                    self.coordinateFile.write(f"{self.frameCounter} \
 {self.imageTimeStamp} \
 {self.app.coords[0]} \
 {self.app.coords[1]} \
@@ -3638,8 +3655,8 @@ class LiveAnalysisQuickButton(ToggleButton):
         self.background_down = self.background_normal
 
         # Bind starting state to be the same as the config
-        app = App.get_running_app()
-        showliveanalysis = app.config.getboolean('LiveAnalysis', 'showliveanalysis')
+        self.app: GlowTrackerApp = App.get_running_app()
+        showliveanalysis = self.app.config.getboolean('LiveAnalysis', 'showliveanalysis')
 
         if showliveanalysis:
             self.state = 'down'
@@ -3653,27 +3670,39 @@ class LiveAnalysisQuickButton(ToggleButton):
     def on_state(self, button: ToggleButton, state: 'str'):
         
         # Update config and setting
-        app = App.get_running_app()
-
         # Pass on start up
-        if app.root is None:
+        if self.app.root is None:
             return
         
-        liveanalysislabel: LiveAnalysisLabel = app.root.ids.middlecolumn.ids.liveanalysislabel
+        liveanalysislabel: LiveAnalysisLabel = self.app.root.ids.middlecolumn.ids.liveanalysislabel
 
         if state == 'normal':
+            # Switch off
             self.text = self.normalText
-            app.config.set('LiveAnalysis', 'showliveanalysis', 0)
+            self.app.config.set('LiveAnalysis', 'showliveanalysis', 0)
             liveanalysislabel.disabled = True
             liveanalysislabel.opacity = 0
 
+            # Clear LiveAnalysis data
+            liveAnalysisData: LiveAnalysisData = self.app.root.ids.middlecolumn.ids.runtimecontrols.imageacquisitionmanager.liveAnalysisData
+            with liveAnalysisData.lock:
+                liveAnalysisData.minBrightness = 0
+                liveAnalysisData.maxBrightness = 0
+                liveAnalysisData.meanBrightness = 0
+                liveAnalysisData.medianBrightness = 0
+                liveAnalysisData.skewness = 0
+                liveAnalysisData.percentile_5 = 0
+                liveAnalysisData.percentile_95 = 0
+            
+
         else:
+            # Switch on
             self.text = self.downText
-            app.config.set('LiveAnalysis', 'showliveanalysis', 1)
+            self.app.config.set('LiveAnalysis', 'showliveanalysis', 1)
             liveanalysislabel.disabled = False
             liveanalysislabel.opacity = 1
         
-        app.config.write()
+        self.app.config.write()
     
 
 class DualColorViewModeQuickButtonLayout(BoxLayout):

--- a/glowtracker/GlowTracker.py
+++ b/glowtracker/GlowTracker.py
@@ -69,6 +69,8 @@ from overrides import override
 from typing import List, Tuple
 from io import TextIOWrapper
 import zaber_motion     # We need to import zaber_motion before pypylon to prevent environment crash
+from zaber_motion.units import Units
+from zaber_motion.unit_table import UnitTable
 from pypylon import pylon
 import platformdirs 
 import shutil
@@ -4261,6 +4263,8 @@ class GlowTrackerApp(App):
     def _keydown(self, instance, key, scancode, codepoint, modifier) -> None:
         """Manage keyboard input for stage and focus"""
         
+        print(f"Keydown")
+
         if self.stage is None:
             return
         
@@ -4283,6 +4287,8 @@ class GlowTrackerApp(App):
         if key not in direction.keys():
             return
         
+        velocity = direction[key]
+
         # Stage movement mode
         if self.moveImageSpaceMode:
             move_img_space = direction[key]
@@ -4292,13 +4298,24 @@ class GlowTrackerApp(App):
             translation_vec_stage_space = self.imageToStageRotMat @ translation_vec_img_space
 
             # Convert back to a 3D tuple
-            translation_vec_stage_space = ( translation_vec_stage_space[1], translation_vec_stage_space[0], move_img_space[2] )
-            
-            self.stage.start_move(translation_vec_stage_space, self.unit)
+            velocity = ( float(translation_vec_stage_space[1]), float(translation_vec_stage_space[0]), move_img_space[2] )
         
-        else:
-            # Move 
-            self.stage.start_move(direction[key], self.unit)
+        # Move 
+        self.stage.start_move(velocity, self.unit)
+
+        # Update stage position app.coords 
+        #   Extrapolated position by speed
+        #   Convert speed to cm/s
+        velocity_cm_per_sec = np.zeros(shape= (3), dtype= np.float32)
+        velocity_cm_per_sec[0] = UnitTable.convert_units(value= velocity[0], from_unit= self.unit, to_unit= Units.VELOCITY_CENTIMETRES_PER_SECOND)
+        velocity_cm_per_sec[1] = UnitTable.convert_units(value= velocity[1], from_unit= self.unit, to_unit= Units.VELOCITY_CENTIMETRES_PER_SECOND)
+        velocity_cm_per_sec[2] = UnitTable.convert_units(value= velocity[2], from_unit= self.unit, to_unit= Units.VELOCITY_CENTIMETRES_PER_SECOND)
+
+        # Very crude estimation. Need to consult Monika
+        spf = 1 / 30.0
+        print(f"velocity_cm_per_sec {velocity_cm_per_sec}")
+        extrapolatedPos = np.array(self.coords) + spf * velocity_cm_per_sec * 10
+        self.coords = extrapolatedPos.tolist()
 
 
     def _keyup(self, instance, key, scancode) -> None:

--- a/glowtracker/GlowTracker.py
+++ b/glowtracker/GlowTracker.py
@@ -3845,6 +3845,7 @@ class DualColorViewModeQuickButton(ToggleButton):
 class Connections(BoxLayout):
     cam_connection = ObjectProperty(None)
     stage_connection = ObjectProperty(None)
+    daq_connection = ObjectProperty(None)
 
     def __init__(self,  **kwargs):
         super(Connections, self).__init__(**kwargs)
@@ -3856,6 +3857,7 @@ class Connections(BoxLayout):
         """
         self.stage_connection.state = 'down'
         self.cam_connection.state = 'down'
+        self.daq_connection.state = 'down'
 
 
     def connectCamera(self):

--- a/glowtracker/GlowTracker.py
+++ b/glowtracker/GlowTracker.py
@@ -396,8 +396,7 @@ class RightColumn(BoxLayout):
         camera = self.app.camera
         stage: Stage = self.app.stage
 
-        if True:
-        # if camera is not None and stage is not None:
+        if camera is not None and stage is not None:
             # Create the calibration widget
             calibrationTabPanel = CalibrationTabPanel()
             calibrationTabPanel.setCloseCallback(closeCallback= self.dismiss_popup)
@@ -413,24 +412,20 @@ class RightColumn(BoxLayout):
     def open_leds(self):
         """Open the LEDs Control Sequence widget popup.
         """
-        if self.app.daqControl is not None:
 
-            # Disabled interaction with preview image widget
-            self.app.root.ids.middlecolumn.ids.scalableimage.disabled = True
-            # Unbind keyboard events
-            self.app.unbind_keys()
+        # Disabled interaction with preview image widget
+        self.app.root.ids.middlecolumn.ids.scalableimage.disabled = True
 
-            # Create LedsControlTabPanel Widget
-            ledsControlTabPanelHolder = LedsControlTabPanelHolder()
-            ledsControlTabPanelHolder.setCloseCallback(closeCallback= self.dismiss_popup)
-            
-            # Launch the widget inside a popup window
-            self._popup = Popup(title= '', separator_height= 0, content= ledsControlTabPanelHolder, size_hint= (0.7, 0.7))
-            self._popup.open()
+        # Unbind keyboard events
+        self.app.unbind_keys()
 
-        else:
-            self._popup = WarningPopup(title="LEDs", text='LEDs Control Panel requires a connection to a DAQ device.', size_hint=(0.5, 0.25), closeTime= 5)
-            self._popup.open()
+        # Create LedsControlTabPanel Widget
+        ledsControlTabPanelHolder = LedsControlTabPanelHolder()
+        ledsControlTabPanelHolder.setCloseCallback(closeCallback= self.dismiss_popup)
+        
+        # Launch the widget inside a popup window
+        self._popup = Popup(title= '', separator_height= 0, content= ledsControlTabPanelHolder, size_hint= (0.7, 0.7))
+        self._popup.open()
 
 
 class MacroScriptWidgetPopup(DragBehavior, Popup):
@@ -999,8 +994,7 @@ class LedsControlTabPanelHolder(FloatLayout):
         app.config.write()
 
         # Update DAQControl
-        if app.daqControl:
-            app.daqControl.ledsMode = LEDsMode[self.mode.text]
+        app.daqControl.ledsMode = LEDsMode[self.mode.text]
 
 
 class LedsControlTabPanel(TabbedPanel):
@@ -1106,11 +1100,12 @@ class LedsControlWidget(BoxLayout):
         self.ledsScriptFile = os.path.abspath(filePath)
         
         # Load the script text
-        print(f'Loading the LEDs control script {self.ledsScriptFile}')
 
         try:
             with open(self.ledsScriptFile, 'r') as file:
                 self.ledsScript = file.read()
+
+            print(f'Loaded LEDs control script {self.ledsScriptFile}')
 
         except FileNotFoundError:
             print(f'The file {self.ledsScriptFile} was not found.')
@@ -1127,14 +1122,12 @@ class LedsControlWidget(BoxLayout):
         self.app.config.write()
 
         # Parse text to command
-        if self.app.daqControl is not None:
-            
-            try:
-                self.app.daqControl.parseTextScript(self.ledsScript)
+        try:
+            self.app.daqControl.parseTextScript(self.ledsScript)
 
-            except Exception as e:
-                print(e)
-                return None
+        except Exception as e:
+            print(e)
+            return None
         
 
     def saveScript(self):
@@ -1169,14 +1162,12 @@ class LedsControlWidget(BoxLayout):
             print(f"Error saving LED script: {e}")
 
         # Then update the current script to daqControl
-        if self.app.daqControl is not None:
-            
-            try:
-                self.app.daqControl.parseTextScript(self.ledsScript)
+        try:
+            self.app.daqControl.parseTextScript(self.ledsScript)
 
-            except Exception as e:
-                print(e)
-                return None
+        except Exception as e:
+            print(e)
+            return None
     
 
 class LedsStageProgramWidget(BoxLayout):
@@ -2057,7 +2048,7 @@ class RecordButton(ImageAcquisitionButton):
         self.savingthread.start()
 
         # Prep DAQ control
-        if self.app.daqControl is not None and self.app.daqControl.ledsMode != LEDsMode.Off:
+        if self.app.daqControl.isConnected() and self.app.daqControl.ledsMode != LEDsMode.Off:
             self.app.daqControl.start()
 
         # Setup image acquisition thread parameters
@@ -2235,7 +2226,7 @@ class RecordButton(ImageAcquisitionButton):
         Clock.schedule_once( resumeButtonsState )
 
         # Reset the DAQ state
-        if self.app.daqControl is not None and self.app.daqControl.ledsMode != LEDsMode.Off:
+        if self.app.daqControl.isConnected() and self.app.daqControl.ledsMode != LEDsMode.Off:
             self.app.daqControl.reset()
     
 
@@ -2336,7 +2327,7 @@ class RecordButton(ImageAcquisitionButton):
 
         # Trigger DAQ Control command
         # Actually, is framecounter.value effected when frame skip?
-        if self.app.daqControl is not None and self.app.daqControl.ledsMode != LEDsMode.Off:
+        if self.app.daqControl.isConnected() and self.app.daqControl.ledsMode != LEDsMode.Off:
 
             imageAcquisitionManager: ImageAcquisitionManager = self.parent
 
@@ -2354,7 +2345,7 @@ class RecordButton(ImageAcquisitionButton):
         self.imageQueue.put(None)
 
         # Reset the DAQ state
-        if self.app.daqControl is not None and self.app.daqControl.ledsMode != LEDsMode.Off:
+        if self.app.daqControl.isConnected() and self.app.daqControl.ledsMode != LEDsMode.Off:
             self.app.daqControl.reset()
 
         # There are two ways to reach this point:
@@ -3820,7 +3811,6 @@ class Connections(BoxLayout):
         """
         self.stage_connection.state = 'down'
         self.cam_connection.state = 'down'
-        self.daq_connection.state = 'down'
 
 
     def connectCamera(self):
@@ -3900,7 +3890,21 @@ class Connections(BoxLayout):
         app.root.ids.leftcolumn.ids.zcontrols.disable_all()
     
 
+class DAQConnectionButton(ToggleButton):
+
+    def on_state(self, widget: Widget, state: str):
+
+        if state == 'down':
+            self.connectDaq()
+        
+        else:
+            self.disconnectDaq()
+
+
     def connectDaq(self):
+        """Connect to a DAQ device.
+        """
+
         print('Connecting DAQ')
         app: GlowTrackerApp = App.get_running_app()
 
@@ -3908,8 +3912,8 @@ class Connections(BoxLayout):
         app.daqControl = DAQControl.createAndConnectDaq()
         
         # If no device
-        if app.daqControl is None:
-            self.daq_connection.state = 'normal'
+        if not app.daqControl.isConnected():
+            self.state = 'normal'
             return
         
         app.daqControl.ledsMode = LEDsMode[app.config.get("LedsControl", "mode")]
@@ -3925,7 +3929,7 @@ class Connections(BoxLayout):
                 print(f'Loaded LEDs control script {recentScriptFile}')
 
         except Exception as e:
-            print(f'Loading recent LEDs control script: {e}')
+            print(f'Error loading recent LEDs control script: {e}')
 
         # Load StageProgram properties
         stageprogrammode = StageProgramMode[app.config.get('LedsControl', 'stageprogrammode')]
@@ -3960,14 +3964,15 @@ class Connections(BoxLayout):
         # Update DAQStageProgram variables
         app.daqControl.daqStageProgram.update(mode= stageprogrammode, quadVertex= quadVertex, exterior= exterior, exteriorConstant= exteriorConstant, gaussianParams= gaussianParams)
 
+        return
+
 
     def disconnectDaq(self):
         print('Disconnecting DAQ')
         app: GlowTrackerApp = App.get_running_app()
 
-        if app.daqControl is not None:
+        if app.daqControl.isConnected():
             app.daqControl.close()
-            app.daqControl = None
 
 
 class MyCounter():
@@ -4036,7 +4041,7 @@ class GlowTrackerApp(App):
         # hardware
         self.camera: basler.Camera | None = None
         self.stage: Stage = Stage(None)
-        self.daqControl: DAQControl | None = None
+        self.daqControl: DAQControl = DAQControl()
         self.updateFpsEvent = None
     
 
@@ -4612,8 +4617,7 @@ class GlowTrackerApp(App):
 
             if key == 'mode':
 
-                if self.daqControl:
-                    self.daqControl.ledsMode = LEDsMode[value]
+                self.daqControl.ledsMode = LEDsMode[value]
 
 
         elif section == 'Developer':
@@ -4733,7 +4737,7 @@ class GlowTrackerApp(App):
             print('Disconnecting Camera')
             self.camera.Close()
         
-        if self.daqControl is not None:
+        if self.daqControl.isConnected():
             print('Disconnecting DAQ')
             self.daqControl.close()
 

--- a/glowtracker/GlowTracker.py
+++ b/glowtracker/GlowTracker.py
@@ -396,6 +396,25 @@ class RightColumn(BoxLayout):
                             size_hint=(0.5, 0.25))
             self._popup.open()
 
+    
+    def open_leds(self):
+        """Open the LEDs Control Sequence widget popup.
+        """
+        
+        # Disabled interaction with preview image widget
+        self.app.root.ids.middlecolumn.ids.scalableimage.disabled = True
+        # Unbind keyboard events
+        self.app.unbind_keys()
+
+        # Create LedsControlWidget Draggable Popup
+        widget = LedsControlWidget(app = self.app)
+        widget.closeCallback = self.dismiss_popup
+        self._popup = MacroScriptWidgetPopup(title= "LEDs Control Sequence", content= widget, size_hint= (0.5, 0.7), auto_dismiss = False)
+        self._popup.closeCallback = self.dismiss_popup
+
+        # Open the widget
+        self._popup.open()
+
 
 class MacroScriptWidgetPopup(DragBehavior, Popup):
 
@@ -934,6 +953,132 @@ class DepthOfFieldCalibration(BoxLayout):
         # Resume the camera to previous state
         liveViewButton.state = prevLiveViewButtonState
 
+
+class LedsControlWidget(BoxLayout):
+    """MacroScriptExecutor widget that holds the parser and the function handler
+    """
+    closeCallback = ObjectProperty(None)
+
+    def __init__(self, **kwargs):
+
+        # Intercept GlowTrackerApp reference object.
+        #   There is a bug that if we call to get reference directly by App().get_running_app(),
+        #   we would get a new GlowTrackerApp object that has different object id, and no config, root, etc. 
+        #   like a completely new object.
+        self.app: GlowTrackerApp = kwargs.pop('app', None)
+        
+        super(LedsControlWidget, self).__init__(**kwargs)
+
+        # Attributes
+        self.macroScriptFile: str = self.ids.macroscriptfile.text
+        self.macroScript: str = ''
+        self._popup: Popup = None
+
+        # Initialize MacroScriptExecutor
+        self.stage = self.app.stage
+        self.camera = self.app.camera
+        self.imageAcquisitionManager: ImageAcquisitionManager = self.app.root.ids.middlecolumn.ids.runtimecontrols.imageacquisitionmanager
+        self.recordButton: RecordButton = self.imageAcquisitionManager.recordbutton
+        position_unit = 'mm'
+
+        # Register appropriate function handler
+        
+
+        # Load the recent script
+        if self.macroScriptFile != '':
+            self.loadMacroScript(self.macroScriptFile)
+
+
+    def openLoadLedsControlWidget(self):
+        """Open a popup to load the macro script.
+        """
+        
+        loadWidget = LoadMacroScriptWidget(load= self._loadScriptWidgetCallback)
+        self._popup = Popup(title= "Load macro script file", content= loadWidget,
+            size_hint= (0.9, 0.9), auto_dismiss= False)
+
+        loadWidget.cancel = self._popup.dismiss
+        self._popup.open()
+
+    
+    def _loadScriptWidgetCallback(self, selection: list[str]):
+        """Load the macro script from a list of given file path. Will choose only the first file.
+        Used for handler of LoadMacroScriptWidget.
+
+        Args:
+            selection (list[str]): list of script file path
+        """
+        # Close the loading widget
+        if self._popup is not None:
+            self._popup.dismiss()
+
+        if len(selection) == 0:
+            return
+        
+        self.loadMacroScript(selection[0])
+    
+    
+    def loadMacroScript(self, filePath: str):
+        """Load the macro script from a given file path.
+
+        Args:
+            filePath (str): _description_
+        """
+        # Get the absolute file path
+        self.macroScriptFile = os.path.abspath(filePath)
+        
+        # Load the script text
+        print(f'Loading the macro script {self.macroScriptFile}')
+
+        try:
+            with open(self.macroScriptFile, 'r') as file:
+                self.macroScript = file.read()
+
+        except FileNotFoundError:
+            print(f'The file {self.macroScriptFile} was not found.')
+
+        except IOError:
+            print(f'An error occurred while reading the file {self.macroScriptFile}.')
+        
+        # Set display text
+        self.ids.macroscriptfile.text = self.macroScriptFile
+        self.ids.macroscripttext.text = self.macroScript
+
+        # Set as recent script
+        self.app.config.set('MacroScript', 'recentscript', self.macroScriptFile)
+        self.app.config.write()
+    
+
+    def saveScript(self):
+        """Save the current macro script into the same file (overwrite if exists).
+        """
+        file_path = self.ids.macroscriptfile.text
+        script = self.ids.macroscripttext.text
+
+        try:
+            # Convert to absolute path if it's a relative path
+            abs_file_path = os.path.abspath(file_path)
+            
+            # Ensure the directory exists
+            directory = os.path.dirname(abs_file_path)
+            if directory:
+                os.makedirs(directory, exist_ok=True)
+            
+            # Open the file in overwrite mode, creating it if it doesn't exist
+            with open(abs_file_path, 'w') as file:
+                file.write(script)
+
+            # Set as recent script
+            self.app.config.set('MacroScript', 'recentscript', self.ids.macroscriptfile.text)
+
+            print(f"Saved the script {file_path}")
+
+        except IOError as e:
+            print(f"Error saving to {file_path}: {e}")
+
+        except Exception as e:
+            print(f"Error saving macro script: {e}")
+    
 
 class StageAxisController(BoxLayout):
     """Template class for stage axis controller widget.

--- a/glowtracker/GlowTracker.py
+++ b/glowtracker/GlowTracker.py
@@ -1082,6 +1082,27 @@ class LedsControlWidget(BoxLayout):
             print(f"Error saving LED script: {e}")
     
 
+class LedsEnableSwitch(Switch):
+
+    def __init__(self, **kwargs):
+        super(LedsEnableSwitch, self).__init__(**kwargs)
+        self.app: GlowTrackerApp = App.get_running_app()
+        self.active = self.app.config.getboolean('LedsControl', 'isenable')
+    
+
+    def on_touch_up(self, touch): 
+        """On switch touch up callback. Update the config value 'isenable',
+
+        Args:
+            touch (Touch): touch input data.
+        """
+        super(LedsEnableSwitch, self).on_touch_up(touch)
+
+        self.app.daqControl.isEnable = self.active
+        self.app.config.set('LedsControl', 'isenable', int(self.active))
+        self.app.config.write()
+
+
 class StageAxisController(BoxLayout):
     """Template class for stage axis controller widget.
     """    
@@ -1222,6 +1243,8 @@ class ContinuousSwitch(Switch):
             self.app.config.set('Experiment', 'iscontinuous', False)
             recordingSettings.ids.duration.disabled = False
             recordingSettings.ids.frames.disabled = False
+        
+        self.app.config.write()
 
 
 class CameraProperties(GridLayout):
@@ -1544,7 +1567,9 @@ class ImageAcquisitionButton(ToggleButton):
     def finishAcquisitionCallback(self) -> None:
         """Finished the acquisition looping callback. Needs to be overridden.
         """        
-        pass
+        # Reset the DAQ state
+        if self.app.daqControl is not None:
+            self.app.daqControl.reset()
 
 
     def updateDisplayImage(self, dt) -> None:
@@ -3486,6 +3511,8 @@ class Connections(BoxLayout):
         
         if app.daqControl is None:
             self.daq_connection.state = 'normal'
+        
+        app.daqControl.isEnable = app.config.getboolean("LedsControl", "isenable")
 
 
     def disconnectDaq(self):
@@ -3699,7 +3726,8 @@ class GlowTrackerApp(App):
         })
 
         config.setdefaults('LedsControl', {
-            'recentscript': ''
+            'recentscript': '',
+            'isenable': 'false'
         })
 
         config.setdefaults('Developer', {
@@ -4098,6 +4126,16 @@ class GlowTrackerApp(App):
                 self.root.ids.middlecolumn.ids.runtimecontrols.ids.liveanalysisquickbutton.state = \
                     'down' if showliveanalysis else 'normal'
             
+
+        elif section == 'LedsControl':
+
+            if key == 'isenable':
+                updateOverlayFlag = True
+
+                # Also update the TrackingOverlay Quick Button
+                isenable = bool(int(value))
+                self.daqControl.isEnable = isenable
+
 
         elif section == 'Developer':
 

--- a/glowtracker/GlowTracker.py
+++ b/glowtracker/GlowTracker.py
@@ -1207,7 +1207,6 @@ class LedsStageProgramEnableSwitch(Switch):
 class LedsStageTextInput(TextInput):
     configKey = StringProperty()
 
-    @override
     def on_kv_post(self, *args):
         app = App.get_running_app()
         self.text = app.config.get('LedsControl', self.configKey)

--- a/glowtracker/Microscope_macros.py
+++ b/glowtracker/Microscope_macros.py
@@ -1268,33 +1268,54 @@ class Vertex2D:
     
 
     @staticmethod
-    def lerp2dVal(a: Vertex2D, b: Vertex2D, t: float) -> Vertex2D:
+    def lerp2d(a: Vertex2D, b: Vertex2D, t: float) -> Vertex2D:
             point = a.point + (b.point - a.point) * t
-            value = a.value * t + b.value * (1 - t)
+            value = a.value + (b.value - a.value) * t
             return Vertex2D(point, value)
 
 
     @staticmethod
     def projPointToLineSegment(a: Vertex2D, b: Vertex2D, p: np.ndarray) -> Vertex2D:
 
-        segmentLength = np.linalg.norm(a.point - b.point)
+        ab = b.point - a.point
+        len_ab = np.linalg.norm(ab)
 
-        if segmentLength == 0:
+        ap = p - a.point
+
+        if len_ab == 0:
             return Vertex2D(a.point, a.value)
-
+        
         # Compute projection
-        t = np.sum((p - a.point) * (b.point - a.point)) / segmentLength
+        proj_ap_on_ab = np.dot(ab, ap) / len_ab
 
-        if t > 1 or t < 0:
+        t = proj_ap_on_ab / len_ab
+
+        if t < 0 or t > 1:
             # The projection lies outside the segment
             return Vertex2D(a.point, a.value)
 
-        return Vertex2D.lerp2dVal(a, b, t)
+        return Vertex2D.lerp2d(a, b, t)
     
 
     @staticmethod
-    def isInsideFourPoint(v0: Vertex2D, v1: Vertex2D, v2: Vertex2D, v3: Vertex2D, p: np.ndarray) -> bool:
-        return True
+    def cross(x: np.ndarray, y: np.ndarray) -> np.ndarray:
+        return x[..., 0] * y[..., 1] - x[..., 1] * y[..., 0]
+    
+
+    @staticmethod
+    def isInsideFourPoints(v0: Vertex2D, v1: Vertex2D, v2: Vertex2D, v3: Vertex2D, p: np.ndarray) -> bool:
+        
+        def isOnLeftSide(a: np.ndarray, b: np.ndarray, p: np.ndarray) -> bool:
+            vab = b - a
+            vap = p - a
+            if Vertex2D.cross(vab, vap) >= 0:
+                return True
+            return False
+        
+        return isOnLeftSide(v0.point, v1.point, p) \
+            and isOnLeftSide(v1.point, v2.point, p) \
+            and isOnLeftSide(v2.point, v3.point, p) \
+            and isOnLeftSide(v3.point, v0.point, p)
 
 
     @staticmethod
@@ -1314,20 +1335,25 @@ class Vertex2D:
             float: Interpolated value
         """
         # Check if inside four points
-        if Vertex2D.isInsideFourPoint(v0, v1, v2, v3, p):
+        if Vertex2D.isInsideFourPoints(v0, v1, v2, v3, p):
+
+            # return 1
 
             # Project p onto line segment p0 <-> p1
             proj_p01 = Vertex2D.projPointToLineSegment(v0, v1, p)
             # Project p onto line segment p2 <-> p3
-            proj_p23 = Vertex2D.projPointToLineSegment(v2, v3, p)
+            proj_p32 = Vertex2D.projPointToLineSegment(v3, v2, p)
             
-            # Lerp between p01 and p23 by distance
+            # Lerp between p01 and p32 by distance
             v_p_p01 = proj_p01.point - p
             d_p_p01 = np.linalg.norm(v_p_p01)
-            v_p_p23 = proj_p23.point - p
+
+            v_p_p23 = proj_p32.point - p
             d_p_p23 = np.linalg.norm(v_p_p23)
-            total_dist = d_p_p01 + d_p_p01
-            val =  proj_p01.value * (d_p_p01 / total_dist) + proj_p23.value * (d_p_p23 / total_dist)
+
+            total_dist = d_p_p01 + d_p_p23
+
+            val =  proj_p01.value + (d_p_p01 / total_dist) * (proj_p32.value - proj_p01.value)
 
             if np.isnan(val):
                 val = 0

--- a/glowtracker/Microscope_macros.py
+++ b/glowtracker/Microscope_macros.py
@@ -1271,29 +1271,6 @@ class Vertex2D:
             point = a.point + (b.point - a.point) * t
             value = a.value + (b.value - a.value) * t
             return Vertex2D(point, value)
-
-
-    @staticmethod
-    def projPointToLineSegment(a: Vertex2D, b: Vertex2D, p: np.ndarray) -> Vertex2D:
-
-        ab = b.point - a.point
-        len_ab = np.linalg.norm(ab)
-
-        ap = p - a.point
-
-        if len_ab == 0:
-            return Vertex2D(a.point, a.value)
-        
-        # Compute projection
-        proj_ap_on_ab = np.dot(ab, ap) / len_ab
-
-        t = proj_ap_on_ab / len_ab
-
-        if t < 0 or t > 1:
-            # The projection lies outside the segment
-            return Vertex2D(a.point, a.value)
-
-        return Vertex2D.lerp2d(a, b, t)
     
 
     @staticmethod
@@ -1320,14 +1297,14 @@ class Vertex2D:
     @staticmethod
     def invBilinear( a, b, c, d, p ) -> np.ndarray:
         """Solve for u,v parameter in quadrilateral through bilinear.
-        Ref: https://iquilezles.org/articles/ibilinear/
+        Refs: https://iquilezles.org/articles/ibilinear/, https://www.shadertoy.com/view/lsBSDm
 
         Args:
-            a (np.ndarray): _description_
-            b (np.ndarray): _description_
-            c (np.ndarray): _description_
-            d (np.ndarray): _description_
-            p (np.ndarray): _description_
+            a (np.ndarray): v0
+            b (np.ndarray): v1
+            c (np.ndarray): v2
+            d (np.ndarray): v3
+            p (np.ndarray): point to find the uv coordinate
 
         Returns:
             np.ndarray: u,v parameters
@@ -1343,7 +1320,7 @@ class Vertex2D:
         k1 = Vertex2D.cross( e, f ) + Vertex2D.cross( h, g )
         k0 = Vertex2D.cross( h, e )
         
-        w = k1*k1 - 4.0*k0*k2
+        w = k1*k1 - 4*k0*k2
         
         if w<=0.001:
             uv[0] = -1
@@ -1353,21 +1330,21 @@ class Vertex2D:
         w = np.sqrt( w )
         
         # will fail for k0=0, which is only on the ba edge 
-        if k0<=0.001 and k0>=-0.001:
+        if k0 <= 0.001 and k0 >= -0.001:
             uv[0] = -1
             uv[1] = -1
             return uv
         
-        v = 2.0*k0/(-k1 - w) 
+        v = 2*k0/(-k1 - w) 
 
-        if v<0.0 or v>1.0:
-            v = 2.0*k0/(-k1 + w)
+        if v < 0 or v > 1:
+            v = 2*k0 / (-k1 + w)
 
-        ta = (e[0] + g[0]*v)
-        ta = ta + 0.001*(1 - np.abs(math.copysign(1,ta)))
+        ta = e[0] + g[0]*v
+        ta = ta + 0.001 * (1 - np.abs(math.copysign(1,ta)))
         
         u = (h[0] - f[0]*v)/ta
-        if u<0.0 or u>1.0 or v<0.0 or v>1.0:
+        if u < 0 or u > 1 or v < 0 or v > 1:
             uv[0] = -1
             uv[1] = -1
             return uv

--- a/glowtracker/Microscope_macros.py
+++ b/glowtracker/Microscope_macros.py
@@ -1,3 +1,7 @@
+# Python
+from __future__ import annotations
+from enum import Enum
+
 # 
 # IO, Utils
 # 
@@ -1247,3 +1251,98 @@ class DepthOfFieldEstimator:
         bestFocusImage = self.dofDataFrame.iloc[bestFocusIndex]['image']
         bestFocusValue = self.dofDataFrame.iloc[bestFocusIndex]['estimatedFocus']
         return bestFocusPosition, bestFocusImage, bestFocusValue
+
+
+class Exterior(Enum):
+    Zero = 'Zero'
+    Nearest = 'Nearest'
+    Constant = 'Constant'
+
+
+class Vertex2D:
+
+    def __init__(self, point: np.ndarray, value: float, name: str = ''):
+        self.point = point
+        self.value = value
+        self.name = name
+    
+
+    @staticmethod
+    def lerp2dVal(a: Vertex2D, b: Vertex2D, t: float) -> Vertex2D:
+            point = a.point + (b.point - a.point) * t
+            value = a.value * t + b.value * (1 - t)
+            return Vertex2D(point, value)
+
+
+    @staticmethod
+    def projPointToLineSegment(a: Vertex2D, b: Vertex2D, p: np.ndarray) -> Vertex2D:
+
+        segmentLength = np.linalg.norm(a.point - b.point)
+
+        if segmentLength == 0:
+            return Vertex2D(a.point, a.value)
+
+        # Compute projection
+        t = np.sum((p - a.point) * (b.point - a.point)) / segmentLength
+
+        if t > 1 or t < 0:
+            # The projection lies outside the segment
+            return Vertex2D(a.point, a.value)
+
+        return Vertex2D.lerp2dVal(a, b, t)
+    
+
+    @staticmethod
+    def isInsideFourPoint(v0: Vertex2D, v1: Vertex2D, v2: Vertex2D, v3: Vertex2D, p: np.ndarray) -> bool:
+        return True
+
+
+    @staticmethod
+    def bilerp(v0: Vertex2D, v1: Vertex2D, v2: Vertex2D, v3: Vertex2D, p: np.ndarray, exterior: Exterior = Exterior.Zero, exteriorConstant: float = 0) -> float:
+        """Bilinear interpolate value of a point P if P lies within the four points. The four points must form a convex in its input order i.e. v0 -> v1 -> v2 -> v3
+
+        Args:
+            v0 (Vertex2D): V0
+            v1 (Vertex2D): V1
+            v2 (Vertex2D): V2
+            v3 (Vertex2D): V3
+            p (np.ndarray): 2D point
+            exterior (Exterior, optional): Exterior condition of the value map. Defaults to Exterior.Zero.
+            exteriorConstant (float, optional): In case the exterior condition is Constant. Defaults to 0.
+
+        Returns:
+            float: Interpolated value
+        """
+        # Check if inside four points
+        if Vertex2D.isInsideFourPoint(v0, v1, v2, v3, p):
+
+            # Project p onto line segment p0 <-> p1
+            proj_p01 = Vertex2D.projPointToLineSegment(v0, v1, p)
+            # Project p onto line segment p2 <-> p3
+            proj_p23 = Vertex2D.projPointToLineSegment(v2, v3, p)
+            
+            # Lerp between p01 and p23 by distance
+            v_p_p01 = proj_p01.point - p
+            d_p_p01 = np.linalg.norm(v_p_p01)
+            v_p_p23 = proj_p23.point - p
+            d_p_p23 = np.linalg.norm(v_p_p23)
+            total_dist = d_p_p01 + d_p_p01
+            val =  proj_p01.value * (d_p_p01 / total_dist) + proj_p23.value * (d_p_p23 / total_dist)
+
+            if np.isnan(val):
+                val = 0
+
+            return val
+
+        else:
+            
+            if exterior == Exterior.Zero:
+                return 0
+
+            elif exterior == Exterior.Constant:
+                return exteriorConstant
+            
+            else:
+                # TODO: Project to closest edge and interpolate from it
+                return 0
+        

--- a/glowtracker/Microscope_macros.py
+++ b/glowtracker/Microscope_macros.py
@@ -890,6 +890,9 @@ class CameraAndStageCalibrator:
         # Remove alpha channel at the front
         image_array = image_array[:,:,1:4]
 
+        # Close the figure
+        plt.close(fig= fig)
+
         return image_array
 
 
@@ -1234,6 +1237,9 @@ class DepthOfFieldEstimator:
         plotImage = np.frombuffer(canvas.tostring_argb(), dtype='uint8').reshape(int(height), int(width), 4)
         # Remove alpha channel at the front
         plotImage = plotImage[:,:,1:4]
+
+        # Close the figure
+        plt.close(fig= fig)
 
         return plotImage
     

--- a/glowtracker/Microscope_macros.py
+++ b/glowtracker/Microscope_macros.py
@@ -1255,7 +1255,6 @@ class DepthOfFieldEstimator:
 
 class Exterior(Enum):
     Zero = 'Zero'
-    Nearest = 'Nearest'
     Constant = 'Constant'
 
 
@@ -1316,12 +1315,71 @@ class Vertex2D:
             and isOnLeftSide(v1.point, v2.point, p) \
             and isOnLeftSide(v2.point, v3.point, p) \
             and isOnLeftSide(v3.point, v0.point, p)
+    
+    
+    @staticmethod
+    def invBilinear( a, b, c, d, p ) -> np.ndarray:
+        """Solve for u,v parameter in quadrilateral through bilinear.
+        Ref: https://iquilezles.org/articles/ibilinear/
 
+        Args:
+            a (np.ndarray): _description_
+            b (np.ndarray): _description_
+            c (np.ndarray): _description_
+            d (np.ndarray): _description_
+            p (np.ndarray): _description_
+
+        Returns:
+            np.ndarray: u,v parameters
+        """
+        uv = np.array([0,0], np.float32)
+        
+        e = b-a
+        f = d-a
+        g = a-b+c-d
+        h = p-a
+            
+        k2 = Vertex2D.cross( g, f )
+        k1 = Vertex2D.cross( e, f ) + Vertex2D.cross( h, g )
+        k0 = Vertex2D.cross( h, e )
+        
+        w = k1*k1 - 4.0*k0*k2
+        
+        if w<=0.001:
+            uv[0] = -1
+            uv[1] = -1
+            return uv
+
+        w = np.sqrt( w )
+        
+        # will fail for k0=0, which is only on the ba edge 
+        if k0<=0.001 and k0>=-0.001:
+            uv[0] = -1
+            uv[1] = -1
+            return uv
+        
+        v = 2.0*k0/(-k1 - w) 
+
+        if v<0.0 or v>1.0:
+            v = 2.0*k0/(-k1 + w)
+
+        ta = (e[0] + g[0]*v)
+        ta = ta + 0.001*(1 - np.abs(math.copysign(1,ta)))
+        
+        u = (h[0] - f[0]*v)/ta
+        if u<0.0 or u>1.0 or v<0.0 or v>1.0:
+            uv[0] = -1
+            uv[1] = -1
+            return uv
+            
+        uv[0] = u
+        uv[1] = v
+        return uv
+    
 
     @staticmethod
     def bilerp(v0: Vertex2D, v1: Vertex2D, v2: Vertex2D, v3: Vertex2D, p: np.ndarray, exterior: Exterior = Exterior.Zero, exteriorConstant: float = 0) -> float:
-        """Bilinear interpolate value of a point P if P lies within the four points. The four points must form a convex in its input order i.e. v0 -> v1 -> v2 -> v3
-
+        """Bilinear interpolate value of a point P if P lies within the four points. The four points must form a quadrilateral convex in its input order, i.e. v0 -> v1 -> v2 -> v3
         Args:
             v0 (Vertex2D): V0
             v1 (Vertex2D): V1
@@ -1334,41 +1392,30 @@ class Vertex2D:
         Returns:
             float: Interpolated value
         """
+        val = 0
+
         # Check if inside four points
         if Vertex2D.isInsideFourPoints(v0, v1, v2, v3, p):
 
-            # return 1
+            # Compute normalized uv corrdinate of p
+            uv = Vertex2D.invBilinear(v0.point, v1.point, v2.point, v3.point, p)
 
-            # Project p onto line segment p0 <-> p1
-            proj_p01 = Vertex2D.projPointToLineSegment(v0, v1, p)
-            # Project p onto line segment p2 <-> p3
-            proj_p32 = Vertex2D.projPointToLineSegment(v3, v2, p)
-            
-            # Lerp between p01 and p32 by distance
-            v_p_p01 = proj_p01.point - p
-            d_p_p01 = np.linalg.norm(v_p_p01)
+            # Bilinear-interpolate p on four points using uv coordinate
+            v01_p = Vertex2D.lerp2d(v0, v1, uv[0])
+            v32_p = Vertex2D.lerp2d(v3, v2, uv[0])
+            lerpedP =  Vertex2D.lerp2d(v01_p, v32_p, uv[1])
+            val = lerpedP.value
 
-            v_p_p23 = proj_p32.point - p
-            d_p_p23 = np.linalg.norm(v_p_p23)
-
-            total_dist = d_p_p01 + d_p_p23
-
-            val =  proj_p01.value + (d_p_p01 / total_dist) * (proj_p32.value - proj_p01.value)
-
-            if np.isnan(val):
+            if np.isnan(val) or np.isinf(val):
                 val = 0
-
-            return val
 
         else:
             
             if exterior == Exterior.Zero:
-                return 0
+                val = 0
 
-            elif exterior == Exterior.Constant:
-                return exteriorConstant
-            
             else:
-                # TODO: Project to closest edge and interpolate from it
-                return 0
+                val = exteriorConstant
+            
+        return val
         

--- a/glowtracker/TestFunctions/hardware_trigger_grab.py
+++ b/glowtracker/TestFunctions/hardware_trigger_grab.py
@@ -1,0 +1,201 @@
+import pypylon.pylon as py
+import pypylon.genicam as geni
+import matplotlib.pyplot as plt
+import numpy as np
+import cv2
+import time
+import pandas as pd
+
+
+def testSingleGrab(cam: py.InstantCamera):
+    
+    print("Waiting for trigger signal")
+    grabResult: py.GrabResult = cam.GrabOne(py.waitForever)
+
+    if grabResult.GrabSucceeded():
+
+        print("Successful!")
+
+        img = grabResult.Array
+        retrieveTimestamp = time.perf_counter()
+        conversion_factor = 1e6  # for conversion in ms
+        timestamp = round(grabResult.TimeStamp/conversion_factor, 1)
+        grabResult.Release()
+
+        plt.figure()
+        plt.imshow(img)
+        plt.legend()
+
+        plt.show()
+
+    else:
+        print("Unsuccessful")
+
+
+class TriggeredImage(py.ImageEventHandler):
+
+    def __init__(self):
+        super().__init__()
+
+        self.grab_times = []
+
+        self.images = []
+        self.retrieveTimestamps = []
+        self.timestamps = []
+        
+        
+    def OnImageGrabbed(self, camera, grabResult: py.GrabResult):
+
+        if grabResult.GrabSucceeded():
+            print("Got an image!")
+
+            self.grab_times.append(grabResult.TimeStamp)
+            
+            self.images.append(grabResult.Array)
+
+            self.retrieveTimestamps.append(time.perf_counter())
+            
+            conversion_factor = 1e6  # for conversion in ms
+            timestamp = round(grabResult.TimeStamp/conversion_factor, 1)
+            self.timestamps.append(timestamp)
+
+            grabResult.Release()
+
+        else:
+            print("Grab didn't succeed")
+    
+
+    def OnImagesSkipped(self, camera, countOfSkippedImages):
+        print(countOfSkippedImages, " images have been skipped.")
+
+
+def testLoopGrab(cam: py.InstantCamera):
+
+    # create event handler instance
+    image_timestamps = TriggeredImage()
+
+    # register handler
+    # remove all other handlers
+    cam.RegisterImageEventHandler(image_timestamps, 
+                                py.RegistrationMode_ReplaceAll, 
+                                py.Cleanup_None)
+
+    # start grabbing with background loop
+    cam.StartGrabbingMax(10, py.GrabStrategy_LatestImages, py.GrabLoop_ProvidedByInstantCamera)
+
+    print("Start grabbing 10 images")
+
+    # wait ... or do something relevant
+    while cam.IsGrabbing():
+        time.sleep(0.1)
+
+    # stop grabbing
+    cam.StopGrabbing()
+
+    print("Finished grabbping")
+
+    # Plotting some result
+    plt.figure()
+    frame_delta_s = np.diff(image_timestamps.grab_times)/1.e9
+    plt.plot(frame_delta_s, ".")
+    plt.axhline(np.mean(frame_delta_s))
+    plt.title("grab_times")
+
+    plt.figure()
+    timestampsDif = np.diff(image_timestamps.timestamps)
+    plt.plot(timestampsDif, ".")
+    plt.axhline(np.mean(timestampsDif))
+    plt.title("timestamps (cam)")
+
+
+    plt.figure()
+    retrieveTimestampsDif = np.diff(image_timestamps.retrieveTimestamps)
+    plt.plot(retrieveTimestampsDif, ".")
+    plt.axhline(np.mean(retrieveTimestampsDif))
+    plt.title("timestmps (host)")
+
+    plt.show()
+
+
+def testBurstGrab(cam: py.InstantCamera):
+
+    cam.TriggerSelector.Value = "FrameBurstStart"
+
+    cam.AcquisitionBurstFrameCount.Value = 10
+
+    # create event handler instance
+    image_timestamps = TriggeredImage()
+
+    # register handler
+    # remove all other handlers
+    cam.RegisterImageEventHandler(image_timestamps, 
+                                py.RegistrationMode_ReplaceAll, 
+                                py.Cleanup_None)
+
+    # start grabbing with background loop
+    # cam.StartGrabbingMax(10, , )
+    # cam.StartGrabbing(15, py.GrabStrategy_LatestImages, py.GrabLoop_ProvidedByInstantCamera)
+    cam.StartGrabbing(py.GrabStrategy_OneByOne)
+
+    print("Start grabbing 10 images")
+
+    # wait ... or do something relevant
+    while cam.IsGrabbing():
+        time.sleep(0.1)
+
+    # stop grabbing
+    cam.StopGrabbing()
+
+    print("Finished grabbping")
+
+    # Plotting some result
+    plt.figure()
+    frame_delta_s = np.diff(image_timestamps.grab_times)/1.e9
+    plt.plot(frame_delta_s, ".")
+    plt.axhline(np.mean(frame_delta_s))
+    plt.title("grab_times")
+
+    plt.figure()
+    timestampsDif = np.diff(image_timestamps.timestamps)
+    plt.plot(timestampsDif, ".")
+    plt.axhline(np.mean(timestampsDif))
+    plt.title("timestamps (cam)")
+
+
+    plt.figure()
+    retrieveTimestampsDif = np.diff(image_timestamps.retrieveTimestamps)
+    plt.plot(retrieveTimestampsDif, ".")
+    plt.axhline(np.mean(retrieveTimestampsDif))
+    plt.title("timestmps (host)")
+
+    plt.show()
+
+
+if __name__ == '__main__':
+
+    # open the camera
+    tlf = py.TlFactory.GetInstance()
+    cam = py.InstantCamera(tlf.CreateFirstDevice())
+    cam.Open()
+
+    # Set acquisition mode to hardware trigger
+    cam.TriggerMode.Value = "On"
+
+    # Set Line1 to be input
+    cam.LineSelector.Value = "Line1"
+    cam.LineMode.Value = "Input"
+    
+    # Set trigger source to Line1
+    cam.TriggerSource.Value = "Line1"
+    cam.TriggerSelector.Value = "FrameStart"
+    cam.TriggerActivation.Value = "RisingEdge"
+    
+    
+    # testSingleGrab(cam)
+
+    # testLoopGrab(cam)
+
+    # TODO:
+    testBurstGrab(cam)
+
+    cam.Close()

--- a/glowtracker/TestFunctions/testCameraIO.py
+++ b/glowtracker/TestFunctions/testCameraIO.py
@@ -1,0 +1,78 @@
+from pypylon import pylon, genicam
+import numpy as np
+import time
+import matplotlib.pyplot as plt
+
+    
+if __name__ == '__main__':
+
+    # Init camera
+    camera = pylon.InstantCamera(pylon.TlFactory.GetInstance().CreateFirstDevice())
+    camera.Open()
+
+    # enable all chunks
+    camera.ChunkModeActive.Value = True
+
+    for cf in camera.ChunkSelector.Symbolics:
+        camera.ChunkSelector.Value = cf
+        camera.ChunkEnable.Value = True
+    
+    # Specify FPS and Exposure 
+    #   FPS
+    FPS = 30
+    camera.AcquisitionFrameRateEnable.Value = True
+    camera.AcquisitionFrameRate.Value = float(FPS)
+
+    #   Exposure
+    exposureTime = 30000 # in micro second unit
+    camera.ExposureTime.Value = exposureTime
+
+    print("Preped camera")
+
+    lines = ["Line1", "Line2", "Line3", "Line4"]
+    for line in lines:
+        camera.LineSelector.Value = line
+        # camera.LineMode.Value = "Input"
+        lineMode = camera.LineMode.GetValue();
+        lineStatus = camera.LineStatus.GetValue()
+        print(line, lineMode, lineStatus)
+
+    camera.StartGrabbingMax(100)
+
+    io_res = []
+    while camera.IsGrabbing():
+        with camera.RetrieveResult(1000) as res:
+            time_stamp = res.TimeStamp
+            io_res.append((time_stamp, res.ChunkLineStatusAll.Value))
+
+
+    camera.StopGrabbing()
+
+
+    # list of timestamp + io status
+    print(io_res[:10])
+
+    # simple logic analyzer :-)
+
+    # convert to numpy array
+    io_array = np.array(io_res)
+    # extract first column timestamps
+    x_vals = io_array[:,0]
+    #  start with first timestamp as '0'
+    x_vals -= x_vals[0]
+
+    # extract second column io values
+    y_vals = io_array[:,1]
+    # for each bit plot the graph
+    for bit in range(8):
+        
+        logic_level = ((y_vals & (1<<bit)) != 0)*0.8 +bit
+        # plot in seconds
+        plt.plot(x_vals / 1e9, logic_level, label = bit)
+        
+    plt.xlabel("time [s]")
+    plt.ylabel("IO_LINE [#]")
+    plt.legend()
+    plt.show()
+    x = 2
+

--- a/glowtracker/TestFunctions/testHardWareTriggerAcquisition.py
+++ b/glowtracker/TestFunctions/testHardWareTriggerAcquisition.py
@@ -172,26 +172,30 @@ def triggerSingleCameraAcquisition(daq: u3.U3, camera: pylon.InstantCamera):
     camera.TriggerActivation.Value = "RisingEdge"
 
     # Start camera aquisition one frame in a thread
-    def grabOneFrame(camera) -> pylon.GrabResult:
-        print("begin grabbing")
+    def grabOneFrame(camera: pylon.InstantCamera) -> pylon.GrabResult:
+
+        print("Start grabbing")
         grabResult = camera.GrabOne(pylon.waitForever)
-        print("end grabbing")
+        print("End grabbing")
+
         return grabResult
     
-    # There is some synchronization issue somewhere here...
-    
-    cameraThread = ThreadWithReturn(target=grabOneFrame, args=(camera, ))
+    cameraThread = ThreadWithReturn(target=grabOneFrame, args=(camera,))
     cameraThread.start()
 
+    print("Wait for trigger ready")
+    camera.WaitForFrameTriggerReady(1)
+
+    print("Begin send signal")
     # Send trigger signal
     daq.setDOState(ioNum= u3.FIO0, state= HIGH)
-    
-    time.sleep(0.01)
+    print("End send signal")
     
     # Stop the thread and get the result back
     grabResult: pylon.GrabResult = cameraThread.join()
+    print("Thread is joined")
 
-    if grabResult.GrabSucceeded():
+    if grabResult and grabResult.GrabSucceeded():
 
         print("Successful!")
 
@@ -204,8 +208,6 @@ def triggerSingleCameraAcquisition(daq: u3.U3, camera: pylon.InstantCamera):
         plt.figure()
         plt.imshow(img)
         plt.show()
-
-        x = 2
 
     else:
         print("Unsuccessful")
@@ -227,12 +229,11 @@ if __name__ == '__main__':
     # blinkLED(daq, 0.5)
     
     # Sine wave LED
-    sineWaveLed(daq= daq, mean= 1.5, amplitude= 1.5,  freq= 1, duration= 5, resolution= 0.00001)
+    # sineWaveLed(daq= daq, mean= 1.5, amplitude= 1.5,  freq= 1, duration= 5, resolution= 0.00001)
 
     # Trigger acquisition
-    # triggerSingleCameraAcquisition(daq, camera)
+    triggerSingleCameraAcquisition(daq, camera)
     
-    # daq.setDOState(ioNum= 0, state= 1)
 
 
 

--- a/glowtracker/TestFunctions/testHardWareTriggerAcquisition.py
+++ b/glowtracker/TestFunctions/testHardWareTriggerAcquisition.py
@@ -1,0 +1,242 @@
+import u3
+from pypylon import pylon
+import numpy as np
+import time
+import matplotlib.pyplot as plt
+from threading import Thread
+
+HIGH = 1
+LOW = 0
+
+def setupLabJackU3() -> u3.U3:
+    # Connect to device
+    device = u3.U3()
+    device.debug = False
+    # Set to factory default
+    device.setDefaults()
+    # Calibrate
+    device.getCalibrationData()
+    # Set FIO0, FIO2 to digital 
+    device.configDigital(u3.FIO0, u3.FIO2)
+
+    return device
+
+
+def setupCamera() -> pylon.InstantCamera:
+    # Init camera
+    camera = pylon.InstantCamera( pylon.TlFactory.GetInstance().CreateFirstDevice() )
+
+    camera.Open()
+
+    # Specify FPS and Exposure 
+    #   FPS
+    FPS = 30
+    camera.AcquisitionFrameRateEnable.Value = True
+    camera.AcquisitionFrameRate.Value = float(FPS)
+
+    #   Exposure
+    exposureTime = 30000 # in micro second unit
+    camera.ExposureTime.Value = exposureTime
+
+    return camera
+
+
+def blinkLED(daq: u3.U3, duration: float):
+
+    daq.configDigital(u3.FIO0)
+    daq.setDOState(ioNum= u3.FIO0, state= HIGH)
+    time.sleep(duration)
+    daq.setDOState(ioNum= u3.FIO0, state= LOW)
+
+
+def sineWaveLed(daq: u3.U3, mean: float, amplitude: float, freq: float, duration: float, resolution: float):
+
+    # From testing
+    resolution = max(0.0003, resolution)
+
+    # Generate signal
+    data = np.arange(int(duration / resolution)) % (freq / resolution)
+    data = (data / np.max(data)) * 2 * np.pi
+    data =  np.sin(data) * amplitude + mean
+
+    # Cap signal within safe 0-5 V
+    data = np.clip(data, 0, 5)
+
+    plt.figure()
+    plt.plot(data)
+    plt.show()
+
+    cumOpTime = 0
+    elapseTimeBegin = time.perf_counter()
+    
+    for value in data:
+
+        startTime = time.perf_counter()
+        
+        dac0Val = daq.voltageToDACBits(volts= value, dacNumber= 0, is16Bits= False)
+        dac0Command = u3.DAC0_8(dac0Val)
+        daq.getFeedback(dac0Command)
+        
+        # Wait
+        endTime = time.perf_counter()
+        opTime = endTime - startTime
+        cumOpTime = cumOpTime + opTime
+        waitTime = resolution - opTime
+        if waitTime > 0:
+            time.sleep(waitTime)
+
+    cumOpTime = cumOpTime / (len(data))
+    print(f"Avg OP time {cumOpTime}")        
+
+    elapseTimeEnd = time.perf_counter()
+    print(f"Elapse Time {elapseTimeEnd - elapseTimeBegin}")
+    print(f"Avg update time {(elapseTimeEnd - elapseTimeBegin)/len(data)}")
+
+    # Set back to 0
+    dac0Val = daq.voltageToDACBits(volts= 0, dacNumber= 0, is16Bits= False)
+    dac0Command = u3.DAC0_8(dac0Val)
+    daq.getFeedback(dac0Command)
+
+
+class TriggeredImage(pylon.ImageEventHandler):
+
+    def __init__(self):
+        super().__init__()
+
+        self.grab_times = []
+
+        self.images = []
+        self.retrieveTimestamps = []
+        self.timestamps = []
+        
+        
+    def OnImageGrabbed(self, camera, grabResult: pylon.GrabResult):
+
+        if grabResult.GrabSucceeded():
+            print("Got an image!")
+
+            self.grab_times.append(grabResult.TimeStamp)
+            
+            self.images.append(grabResult.Array)
+
+            self.retrieveTimestamps.append(time.perf_counter())
+            
+            conversion_factor = 1e6  # for conversion in ms
+            timestamp = round(grabResult.TimeStamp/conversion_factor, 1)
+            self.timestamps.append(timestamp)
+
+            grabResult.Release()
+
+        else:
+            print("Grab didn't succeed")
+    
+
+    def OnImagesSkipped(self, camera, countOfSkippedImages):
+        print(countOfSkippedImages, " images have been skipped.")
+
+
+class ThreadWithReturn(Thread):
+    def __init__(self, group=None, target=None, name=None, args=(), kwargs={}, verbose=None):
+        # Initializing the Thread class
+        super().__init__(group, target, name, args, kwargs)
+        self._return = None
+
+    # Overriding the Thread.run function
+    def run(self):
+        if self._target is not None:
+            self._return = self._target(*self._args, **self._kwargs)
+
+    def join(self):
+        super().join()
+        return self._return
+
+
+def triggerSingleCameraAcquisition(daq: u3.U3, camera: pylon.InstantCamera):
+
+    # Prep control signal
+    daq.configDigital(u3.FIO0)
+    daq.setDOState(ioNum= u3.FIO0, state= LOW)
+
+    # 
+    # Set camera to take trigger signal
+    # 
+    camera.TriggerMode.Value = "On"
+
+    #   Set Line1 to be input
+    camera.LineSelector.Value = "Line1"
+    camera.LineMode.Value = "Input"
+    
+    #   Set trigger source to Line1
+    camera.TriggerSource.Value = "Line1"
+    camera.TriggerSelector.Value = "FrameStart"
+    camera.TriggerActivation.Value = "RisingEdge"
+
+    # Start camera aquisition one frame in a thread
+    def grabOneFrame(camera) -> pylon.GrabResult:
+        print("begin grabbing")
+        grabResult = camera.GrabOne(pylon.waitForever)
+        print("end grabbing")
+        return grabResult
+    
+    # There is some synchronization issue somewhere here...
+    
+    cameraThread = ThreadWithReturn(target=grabOneFrame, args=(camera, ))
+    cameraThread.start()
+
+    # Send trigger signal
+    daq.setDOState(ioNum= u3.FIO0, state= HIGH)
+    
+    time.sleep(0.01)
+    
+    # Stop the thread and get the result back
+    grabResult: pylon.GrabResult = cameraThread.join()
+
+    if grabResult.GrabSucceeded():
+
+        print("Successful!")
+
+        img = grabResult.Array
+        retrieveTimestamp = time.perf_counter()
+        conversion_factor = 1e6  # for conversion in ms
+        timestamp = round(grabResult.TimeStamp/conversion_factor, 1)
+        grabResult.Release()
+
+        plt.figure()
+        plt.imshow(img)
+        plt.show()
+
+        x = 2
+
+    else:
+        print("Unsuccessful")
+
+    # Reset signal back to low
+    daq.setDOState(ioNum= u3.FIO0, state= LOW)
+
+
+if __name__ == '__main__':
+
+    daq = setupLabJackU3()
+    camera = setupCamera()
+
+    # Try blinking LED 3 times
+    # blinkLED(daq, 0.5)
+    # time.sleep(0.5)
+    # blinkLED(daq, 0.5)
+    # time.sleep(0.5)
+    # blinkLED(daq, 0.5)
+    
+    # Sine wave LED
+    sineWaveLed(daq= daq, mean= 1.5, amplitude= 1.5,  freq= 1, duration= 5, resolution= 0.00001)
+
+    # Trigger acquisition
+    # triggerSingleCameraAcquisition(daq, camera)
+    
+    # daq.setDOState(ioNum= 0, state= 1)
+
+
+
+    
+
+
+    

--- a/glowtracker/TestFunctions/testHardWareTriggerAcquisition.py
+++ b/glowtracker/TestFunctions/testHardWareTriggerAcquisition.py
@@ -1,3 +1,4 @@
+from typing import List
 import u3
 from pypylon import pylon
 import numpy as np
@@ -160,6 +161,7 @@ def triggerSingleCameraAcquisition(daq: u3.U3, camera: pylon.InstantCamera):
     # 
     # Set camera to take trigger signal
     # 
+    camera.TriggerSelector.Value = "FrameStart"
     camera.TriggerMode.Value = "On"
 
     #   Set Line1 to be input
@@ -168,7 +170,6 @@ def triggerSingleCameraAcquisition(daq: u3.U3, camera: pylon.InstantCamera):
     
     #   Set trigger source to Line1
     camera.TriggerSource.Value = "Line1"
-    camera.TriggerSelector.Value = "FrameStart"
     camera.TriggerActivation.Value = "RisingEdge"
 
     # Start camera aquisition one frame in a thread
@@ -215,10 +216,109 @@ def triggerSingleCameraAcquisition(daq: u3.U3, camera: pylon.InstantCamera):
     # Reset signal back to low
     daq.setDOState(ioNum= u3.FIO0, state= LOW)
 
+def triggerBurstCameraAcquisition(daq: u3.U3, camera: pylon.InstantCamera):
+
+    # Prep control signal
+    # daq.configDigital(u3.FIO0)
+    # daq.setDOState(ioNum= u3.FIO0, state= LOW)
+
+    #   Set Line1 to be input
+    camera.AcquisitionMode.Value = "Continuous"
+
+    camera.TriggerSelector.SetValue("FrameStart")
+    print(camera.TriggerActivation.GetSymbolics())
+
+    camera.LineSelector.Value = "Line1"
+    camera.LineMode.Value = "Input"
+
+    # Set camera to take trigger signal at rising edge
+    camera.TriggerSelector.Value = "FrameStart"
+    camera.TriggerMode.Value = "On"
+    camera.TriggerSource.Value = "Line1"
+    camera.TriggerActivation.Value = "RisingEdge"
+
+
+    # Start camera aquisition one frame in a thread
+    def grabBurst(camera: pylon.InstantCamera) -> pylon.GrabResult:
+
+        print("Start grabbing")
+        grabResults = []
+        numGrabs = 10
+        i = 0
+
+        camera.StartGrabbing(pylon.GrabStrategy_LatestImages)
+
+        print("Started grabbing")
+
+        camera.WaitForFrameTriggerReady(10)
+        
+        while i < numGrabs and camera.IsGrabbing():
+
+            print("-------------v")
+
+            # Poll Line1 state
+            # camera.LineSelector.Value = "Line1"
+            line_state = camera.LineStatus.GetValue()
+            print(f"line_state {line_state}")
+
+            print("Grabbing an image")
+            grabResult = camera.RetrieveResult(100000, pylon.TimeoutHandling_ThrowException)
+
+            line_state = camera.LineStatus.GetValue()
+            print(f"line_state {line_state}")
+
+            if grabResult and grabResult.GrabSucceeded():
+
+                print(f"Successful {i}")
+                img = grabResult.Array
+                grabResults.append(grabResult)
+                grabResult.Release()
+
+            else:
+                print(f"Unsuccessful {i}")
+            
+
+            # Poll Line1 state
+            # camera.LineSelector.Value = "Line1"
+            line_state = camera.LineStatus.GetValue()
+            print(f"line_state {line_state}")
+
+            # if line_state == 0:  # falling edge → LOW
+            #     print("Line1 LOW -> stopping acquisition")
+            #     camera.StopGrabbing()
+            #     break
+
+            i += 1
+
+        print("End grabbing")
+
+        return grabResults
+    
+    cameraThread = ThreadWithReturn(target=grabBurst, args=(camera,))
+    cameraThread.start()
+
+    print("Wait for trigger ready")
+    # camera.WaitForFrameTriggerReady(10000)
+
+    print("Begin send signal")
+    # Send trigger signal
+    # daq.setDOState(ioNum= u3.FIO0, state= HIGH)
+    
+    # Stop the thread and get the result back
+    grabResults: List[pylon.GrabResult] = cameraThread.join()
+    print("Thread is joined")
+
+    if grabResults:
+        print(f"Num images: {len(grabResults)}")
+
+    # Reset signal back to low
+    # daq.setDOState(ioNum= u3.FIO0, state= LOW)
+
 
 if __name__ == '__main__':
 
-    daq = setupLabJackU3()
+    # daq = setupLabJackU3()
+    daq = None
     camera = setupCamera()
 
     # Try blinking LED 3 times
@@ -229,15 +329,12 @@ if __name__ == '__main__':
     # blinkLED(daq, 0.5)
     
     # Sine wave LED
-    # sineWaveLed(daq= daq, mean= 1.5, amplitude= 1.5,  freq= 1, duration= 5, resolution= 0.00001)
+    sineWaveLed(daq= daq, mean= 1.5, amplitude= 1.5,  freq= 1, duration= 5, resolution= 0.00001)
 
-    # Trigger acquisition
-    triggerSingleCameraAcquisition(daq, camera)
-    
+    # Trigger single frame acquisition
+    # triggerSingleCameraAcquisition(daq, camera)
 
-
-
-    
-
+    # Trigger frame burst acquisition
+    # triggerBurstCameraAcquisition(daq, camera)
 
     

--- a/glowtracker/TestFunctions/testHardWareTriggerAcquisition.py
+++ b/glowtracker/TestFunctions/testHardWareTriggerAcquisition.py
@@ -317,8 +317,7 @@ def triggerBurstCameraAcquisition(daq: u3.U3, camera: pylon.InstantCamera):
 
 if __name__ == '__main__':
 
-    # daq = setupLabJackU3()
-    daq = None
+    daq = setupLabJackU3()
     camera = setupCamera()
 
     # Try blinking LED 3 times

--- a/glowtracker/TestFunctions/testLabJack.py
+++ b/glowtracker/TestFunctions/testLabJack.py
@@ -1,0 +1,76 @@
+import u3
+import time
+if __name__ == '__main__':
+
+    # Connect to device
+    device = u3.U3()
+    # print(device.configU3())
+    device.debug = True
+
+
+    # Get calibration data
+    cabDat = device.getCalibrationData()
+    # print(cabDat)
+
+    # Send analog output
+    #   Voltage 1.5, channel DAC0, 8 Bits
+    dac0Val = device.voltageToDACBits(volts= 1, dacNumber= 0, is16Bits= False)
+    print("dac0Val", dac0Val)
+
+    dac1Val = device.voltageToDACBits(volts= 2, dacNumber= 1, is16Bits= False)
+    print("dac1Val", dac1Val)
+
+    #   Create a Feedback command 
+    dac0Command = u3.DAC0_8(dac0Val)
+    dac1Command = u3.DAC1_8(dac1Val)
+    print("dac0Command", dac0Command)
+    print("dac1Command", dac1Command)
+
+    #   Send and get feedback
+    feedback = device.getFeedback(dac0Command, dac1Command)
+    print("feedback", feedback)
+
+    # Get analog input
+    # takes about 30ms for the output to reach target V
+    time.sleep(0.030)
+    # Config FIO0 to be analog
+    device.configAnalog(u3.FIO0)
+    ain0Command = u3.AIN(0, 31, True)
+
+    feedback = device.getFeedback(ain0Command)
+    print("AIN0 feedback", feedback)
+
+    #   Convert analog input bits to voltage
+    ainValue = device.binaryToCalibratedAnalogVoltage(bits= feedback[0], isLowVoltage= True, isSingleEnded= True, isSpecialSetting= False, channelNumber= 0)
+    print("AIN0 vol", ainValue)
+
+    #   Can also read using this helper func
+    newAinValue = device.getAIN(posChannel=0, negChannel=31, longSettle=False, quickSample=False)
+    print("Another AIN0 vol", newAinValue)
+
+    #
+    # Output and Input digital signals
+    # 
+    # Set FIO to digital 
+    device.configDigital(u3.FIO0, u3.FIO2)
+    # Set digital output at FI00
+    device.setFIOState(fioNum= 0, state= 1)
+    # device.setDOState(ioNum= 0, state= 1)
+
+    # Get digital input at FI01
+    inputState = device.getDIState(ioNum= 2)
+    print(f"FIO2 Input state {inputState}")
+    
+
+    # Set digital output at FI00
+    device.setDOState(ioNum= 0, state= 0)
+
+    # Get digital input at FI01
+    inputState = device.getDIState(ioNum= 2)
+    print(f"FIO2 Input state {inputState}")
+
+
+    
+
+
+    

--- a/glowtracker/layout.kv
+++ b/glowtracker/layout.kv
@@ -1114,6 +1114,7 @@ MainWindow:
     pos: root.pos
     orientation: 'vertical'
     spacing: dp(10)
+    exterior: exterior
     constanttextinput: constanttextinput
     p1x: p1x
     p1y: p1y
@@ -1167,21 +1168,18 @@ MainWindow:
                     text_size: [dp(100), root.height]
                 
                 Spinner:
+                    id: exterior
                     text: 'Zero'
                     values: 'Zero', 'Nearest', 'Constant'
-                    on_text: print("The Exterior value spinner {} has text {}".format(self, self.text))
+                    on_kv_post: root.updateExteriorChoice()
+                    on_text: root.updateExteriorChoice()
                     size_hint_x: None
                     width: dp(100)
                 
-                TextInput:
+                LedsStageTextInput:
                     id: constanttextinput
-                    multiline: False
-                    text: ''
-                    input_filter: 'float'
-                    base_direction: 'rtl'
                     on_text_validate: root.updateLedStageProgram()
-                    disabled: True
-                    size_hint_x: 1
+                    configKey: 'constanttextinput'
 
             BoxLayout:
                 orientation: 'horizontal'
@@ -1214,28 +1212,19 @@ MainWindow:
                     size_hint_x: None
                     text_size: [dp(100), root.height]
 
-                TextInput:
+                LedsStageTextInput:
                     id: p1x
-                    multiline: False
-                    text: ''
-                    input_filter: 'float'
-                    base_direction: 'rtl'
+                    configKey: 'p1x'
                     on_text_validate: root.updateLedStageProgram()
                 
-                TextInput:
+                LedsStageTextInput:
                     id: p1y
-                    multiline: False
-                    text: ''
-                    input_filter: 'float'
-                    base_direction: 'rtl'
+                    configKey: 'p1y'
                     on_text_validate: root.updateLedStageProgram()
                 
-                TextInput:
+                LedsStageTextInput:
                     id: p1v
-                    multiline: False
-                    text: ''
-                    input_filter: 'float'
-                    base_direction: 'rtl'
+                    configKey: 'p1v'
                     on_text_validate: root.updateLedStageProgram()
 
             BoxLayout:
@@ -1250,28 +1239,19 @@ MainWindow:
                     size_hint_x: None
                     text_size: [dp(100), root.height]
 
-                TextInput:
+                LedsStageTextInput:
                     id: p2x
-                    multiline: False
-                    text: ''
-                    input_filter: 'float'
-                    base_direction: 'rtl'
+                    configKey: 'p2x'
                     on_text_validate: root.updateLedStageProgram()
                 
-                TextInput:
+                LedsStageTextInput:
                     id: p2y
-                    multiline: False
-                    text: ''
-                    input_filter: 'float'
-                    base_direction: 'rtl'
+                    configKey: 'p2y'
                     on_text_validate: root.updateLedStageProgram()
                 
-                TextInput:
+                LedsStageTextInput:
                     id: p2v
-                    multiline: False
-                    text: ''
-                    input_filter: 'float'
-                    base_direction: 'rtl'
+                    configKey: 'p2v'
                     on_text_validate: root.updateLedStageProgram()
             
             BoxLayout:
@@ -1286,28 +1266,19 @@ MainWindow:
                     size_hint_x: None
                     text_size: [dp(100), root.height]
 
-                TextInput:
+                LedsStageTextInput:
                     id: p3x
-                    multiline: False
-                    text: ''
-                    input_filter: 'float'
-                    base_direction: 'rtl'
+                    configKey: 'p3x'
                     on_text_validate: root.updateLedStageProgram()
                 
-                TextInput:
+                LedsStageTextInput:
                     id: p3y
-                    multiline: False
-                    text: ''
-                    input_filter: 'float'
-                    base_direction: 'rtl'
+                    configKey: 'p3y'
                     on_text_validate: root.updateLedStageProgram()
                 
-                TextInput:
+                LedsStageTextInput:
                     id: p3v
-                    multiline: False
-                    text: ''
-                    input_filter: 'float'
-                    base_direction: 'rtl'
+                    configKey: 'p3v'
                     on_text_validate: root.updateLedStageProgram()
 
             BoxLayout:
@@ -1322,28 +1293,19 @@ MainWindow:
                     size_hint_x: None
                     text_size: [dp(100), root.height]
 
-                TextInput:
+                LedsStageTextInput:
                     id: p4x
-                    multiline: False
-                    text: ''
-                    input_filter: 'float'
-                    base_direction: 'rtl'
+                    configKey: 'p4x'
                     on_text_validate: root.updateLedStageProgram()
                 
-                TextInput:
+                LedsStageTextInput:
                     id: p4y
-                    multiline: False
-                    text: ''
-                    input_filter: 'float'
-                    base_direction: 'rtl'
+                    configKey: 'p4y'
                     on_text_validate: root.updateLedStageProgram()
                 
-                TextInput:
+                LedsStageTextInput:
                     id: p4v
-                    multiline: False
-                    text: ''
-                    input_filter: 'float'
-                    base_direction: 'rtl'
+                    configKey: 'p4v'
                     on_text_validate: root.updateLedStageProgram()
             
         BoxLayout:
@@ -1388,6 +1350,14 @@ MainWindow:
 <LedsStageProgramEnableSwitch>:
     size: root.size
     pos: root.pos
+
+
+<LedsStageTextInput>:
+    multiline: False
+    input_filter: 'float'
+    base_direction: 'rtl'
+    size_hint_x: 1
+    write_tab: False
 
 ### display if hardware is connected successfully     
 <Connections>:

--- a/glowtracker/layout.kv
+++ b/glowtracker/layout.kv
@@ -1088,7 +1088,7 @@ MainWindow:
     size_hint: (0.3, 1)
     cam_connection: cam_connection
     stage_connection: stage_connection
-    dac_connection: dac_connection
+    daq_connection: daq_connection
     
     Label:
         text: 'Camera'
@@ -1119,10 +1119,10 @@ MainWindow:
         on_state: root.connectStage() if self.state=='down' else root.disconnectStage()
 
     Label:
-        text: 'DAC'
+        text: 'DAQ'
         size_hint: (1,0.33)
     OnOffButton:
-        id: dac_connection 
+        id: daq_connection 
         border: 0,0,0,0
         size_hint_x: 0.3
         size_hint_y: None
@@ -1130,7 +1130,7 @@ MainWindow:
         pos_hint: {'center_x': .5, 'center_y': .5}
         background_normal: 'icons/connection_off.png'
         background_down: 'icons/connection_on.png'
-        on_state: root.connectDac() if self.state=='down' else root.disconnectDac()
+        on_state: root.connectDaq() if self.state=='down' else root.disconnectDaq()
     
         
       

--- a/glowtracker/layout.kv
+++ b/glowtracker/layout.kv
@@ -1033,6 +1033,41 @@ MainWindow:
             on_release: root.closeCallback()
 
 
+<LedsControlTabPanelHolder>:
+
+    mode: mode
+
+    LedsControlTabPanel:
+        id: ledscontroltabpanel
+        size_hint: 1, 1
+        pos_hint: {"center_x": 0.5, "center_y": 0.5}
+
+
+    BoxLayout:
+        orientation: 'horizontal'
+        size_hint: None, None
+        size: self.minimum_size
+        spacing: '6dp'
+        pos_hint: {"right": 1, "top": 1}
+
+        Label:
+            text: '[b][color=018EFF]LEDs Mode[/color][/b]'
+            size_hint_x: None
+            width: self.texture_size[0]
+            markup: True
+
+
+        Spinner:
+            size_hint: None, None
+            size: '100dp', '40dp'
+            id: mode
+            text: 'Off'
+            values: 'Off', 'Sequencer', 'StageProgram'
+            on_text: root.updateMode()
+            on_kv_post: self.text = app.config.get('LedsControl', 'mode')
+
+
+
 <LedsControlTabPanel>:
     size: root.size
     pos: root.pos
@@ -1091,17 +1126,9 @@ MainWindow:
             orientation: 'vertical'
             size_hint_x: None
 
-            Label:
-                text: 'Enable'
-                size_hint_y: 0.1
-                
-            LedsSequencerEnableSwitch:
-                id: ledssequencerenableswitch
-                size_hint_y: 0.1
-            
             BoxLayout:
                 # Filler
-                size_hint_y: 0.7
+                size_hint_y: 0.9
 
             Button:
                 text: "Close"
@@ -1143,18 +1170,20 @@ MainWindow:
                 size_hint_y: 0.1
 
                 Label:
-                    text: 'Enable'
+                    text: 'Mode'
                     halign: 'center'
                     valign: 'middle'
                     size_hint_x: None
                     text_size: [dp(100), root.height]
                 
-                LedsStageProgramEnableSwitch:
+                Spinner:
+                    id: modeSpinner
+                    text: 'FourPoint'
+                    values: 'FourPoint', 'Gaussian'
+                    # on_text: root.updateExteriorChoice(); root.updateLedStageProgram()
                     size_hint_x: None
                     width: dp(100)
-                    id: ledsstageprogramenableswitch
-            
-
+                
             BoxLayout:
                 orientation: 'horizontal'
                 size_hint_y: 0.1
@@ -1340,16 +1369,6 @@ MainWindow:
             text: "Close"
             size_hint_x: .2
             on_release: root.closeCallback()
-
-
-<LedsSequencerEnableSwitch>:
-    size: root.size
-    pos: root.pos
-
-
-<LedsStageProgramEnableSwitch>:
-    size: root.size
-    pos: root.pos
 
 
 <LedsStageTextInput>:

--- a/glowtracker/layout.kv
+++ b/glowtracker/layout.kv
@@ -1064,7 +1064,7 @@ MainWindow:
 
         TextInput:
             id: ledsscriptfile
-            text: app.config.get('LedsControl', 'recentscript')
+            text: app.config.get('LedsControl', 'ledsequencescript')
             size_hint_x: 0.8
         
         Button:

--- a/glowtracker/layout.kv
+++ b/glowtracker/layout.kv
@@ -1142,6 +1142,7 @@ MainWindow:
     orientation: 'vertical'
     spacing: dp(10)
     exteriorSpinner: exteriorSpinner
+    modeSpinner: modeSpinner
     constanttextinput: constanttextinput
     p1x: p1x
     p1y: p1y
@@ -1155,12 +1156,29 @@ MainWindow:
     p4x: p4x
     p4y: p4y
     p4v: p4v
+    exterior_layout: exterior_layout
+    fourpoint_header_layout: fourpoint_header_layout
+    p1_layout: p1_layout
+    p2_layout: p2_layout
+    p3_layout: p3_layout
+    p4_layout: p4_layout
+    g_amplitude: g_amplitude
+    g_x_mean: g_x_mean
+    g_x_sigma: g_x_sigma
+    g_y_mean: g_y_mean
+    g_y_sigma: g_y_sigma
+    g_amplitude_layout: g_amplitude_layout
+    g_x_mean_layout: g_x_mean_layout
+    g_x_sigma_layout: g_x_sigma_layout
+    g_y_mean_layout: g_y_mean_layout
+    g_y_sigma_layout: g_y_sigma_layout
 
     BoxLayout:
         orientation: 'horizontal'
         spacing: dp(10)
 
         StackLayout:
+            id: stacklayout
             orientation: 'tb-lr'
             size_hint_x: 0.5
             spacing: [0, dp(5)]
@@ -1180,11 +1198,12 @@ MainWindow:
                     id: modeSpinner
                     text: 'FourPoint'
                     values: 'FourPoint', 'Gaussian'
-                    # on_text: root.updateExteriorChoice(); root.updateLedStageProgram()
+                    on_text: root.updateMode(); root.updateLedStageProgram()
                     size_hint_x: None
                     width: dp(100)
                 
             BoxLayout:
+                id: exterior_layout
                 orientation: 'horizontal'
                 size_hint_y: 0.1
                 size_hint_x: 0.9
@@ -1207,10 +1226,11 @@ MainWindow:
                 LedsStageTextInput:
                     id: constanttextinput
                     on_kv_post: root.updateExteriorChoice()
-                    on_text_validate: root.updateLedStageProgram()
+                    root: root
                     configKey: 'constanttextinput'
 
             BoxLayout:
+                id: fourpoint_header_layout
                 orientation: 'horizontal'
                 size_hint_y: 0.1
                 size_hint_x: 0.9
@@ -1227,9 +1247,10 @@ MainWindow:
                     text: 'y (mm)'
                 
                 Label:
-                    text: 'z (mm)'
+                    text: 'Voltage'
 
             BoxLayout:
+                id: p1_layout
                 orientation: 'horizontal'
                 size_hint_y: 0.1
                 size_hint_x: 0.9
@@ -1244,19 +1265,20 @@ MainWindow:
                 LedsStageTextInput:
                     id: p1x
                     configKey: 'p1x'
-                    on_text_validate: root.updateLedStageProgram()
+                    root: root
                 
                 LedsStageTextInput:
                     id: p1y
                     configKey: 'p1y'
-                    on_text_validate: root.updateLedStageProgram()
+                    root: root
                 
                 LedsStageTextInput:
                     id: p1v
                     configKey: 'p1v'
-                    on_text_validate: root.updateLedStageProgram()
+                    root: root
 
             BoxLayout:
+                id: p2_layout
                 orientation: 'horizontal'
                 size_hint_y: 0.1
                 size_hint_x: 0.9
@@ -1271,19 +1293,20 @@ MainWindow:
                 LedsStageTextInput:
                     id: p2x
                     configKey: 'p2x'
-                    on_text_validate: root.updateLedStageProgram()
+                    root: root
                 
                 LedsStageTextInput:
                     id: p2y
                     configKey: 'p2y'
-                    on_text_validate: root.updateLedStageProgram()
+                    root: root
                 
                 LedsStageTextInput:
                     id: p2v
                     configKey: 'p2v'
-                    on_text_validate: root.updateLedStageProgram()
+                    root: root
             
             BoxLayout:
+                id: p3_layout
                 orientation: 'horizontal'
                 size_hint_y: 0.1
                 size_hint_x: 0.9
@@ -1298,19 +1321,20 @@ MainWindow:
                 LedsStageTextInput:
                     id: p3x
                     configKey: 'p3x'
-                    on_text_validate: root.updateLedStageProgram()
+                    root: root
                 
                 LedsStageTextInput:
                     id: p3y
                     configKey: 'p3y'
-                    on_text_validate: root.updateLedStageProgram()
+                    root: root
                 
                 LedsStageTextInput:
                     id: p3v
                     configKey: 'p3v'
-                    on_text_validate: root.updateLedStageProgram()
+                    root: root
 
             BoxLayout:
+                id: p4_layout
                 orientation: 'horizontal'
                 size_hint_y: 0.1
                 size_hint_x: 0.9
@@ -1325,17 +1349,110 @@ MainWindow:
                 LedsStageTextInput:
                     id: p4x
                     configKey: 'p4x'
-                    on_text_validate: root.updateLedStageProgram()
+                    root: root
                 
                 LedsStageTextInput:
                     id: p4y
                     configKey: 'p4y'
-                    on_text_validate: root.updateLedStageProgram()
+                    root: root
                 
                 LedsStageTextInput:
                     id: p4v
                     configKey: 'p4v'
-                    on_text_validate: root.updateLedStageProgram()
+                    root: root
+            
+            BoxLayout:
+                id: g_amplitude_layout
+                orientation: 'horizontal'
+                size_hint_y: 0.1
+                size_hint_x: 0.9
+
+                Label:
+                    text: 'Amplitude'
+                    halign: 'center'
+                    valign: 'middle'
+                    size_hint_x: None
+                    text_size: [dp(100), root.height]
+
+                LedsStageTextInput:
+                    id: g_amplitude
+                    configKey: 'g_amplitude'
+                    root: root
+            
+            BoxLayout:
+                id: g_x_mean_layout
+                orientation: 'horizontal'
+                size_hint_y: 0.1
+                size_hint_x: 0.9
+
+                Label:
+                    text: 'X mean'
+                    halign: 'center'
+                    valign: 'middle'
+                    size_hint_x: None
+                    text_size: [dp(100), root.height]
+
+                LedsStageTextInput:
+                    id: g_x_mean
+                    configKey: 'g_x_mean'
+                    root: root
+            
+            BoxLayout:
+                id: g_x_sigma_layout
+                orientation: 'horizontal'
+                size_hint_y: 0.1
+                size_hint_x: 0.9
+
+                Label:
+                    text: 'X sigma'
+                    halign: 'center'
+                    valign: 'middle'
+                    size_hint_x: None
+                    text_size: [dp(100), root.height]
+
+                LedsStageTextInput:
+                    id: g_x_sigma
+                    configKey: 'g_x_sigma'
+                    root: root
+            
+
+            BoxLayout:
+                id: g_y_mean_layout
+                orientation: 'horizontal'
+                size_hint_y: 0.1
+                size_hint_x: 0.9
+
+                Label:
+                    text: 'Y mean'
+                    halign: 'center'
+                    valign: 'middle'
+                    size_hint_x: None
+                    text_size: [dp(100), root.height]
+
+                LedsStageTextInput:
+                    id: g_y_mean
+                    configKey: 'g_y_mean'
+                    root: root
+            
+            
+            BoxLayout:
+                id: g_y_sigma_layout
+                orientation: 'horizontal'
+                size_hint_y: 0.1
+                size_hint_x: 0.9
+
+                Label:
+                    text: 'Y sigma'
+                    halign: 'center'
+                    valign: 'middle'
+                    size_hint_x: None
+                    text_size: [dp(100), root.height]
+
+                LedsStageTextInput:
+                    id: g_y_sigma
+                    configKey: 'g_y_sigma'
+                    root: root
+            
             
         BoxLayout:
             orientation: 'vertical'

--- a/glowtracker/layout.kv
+++ b/glowtracker/layout.kv
@@ -1142,6 +1142,7 @@ MainWindow:
     orientation: 'vertical'
     spacing: dp(10)
     exteriorSpinner: exteriorSpinner
+
     modeSpinner: modeSpinner
     constanttextinput: constanttextinput
     p1x: p1x
@@ -1156,12 +1157,15 @@ MainWindow:
     p4x: p4x
     p4y: p4y
     p4v: p4v
+    relative: relative
     exterior_layout: exterior_layout
     fourpoint_header_layout: fourpoint_header_layout
     p1_layout: p1_layout
     p2_layout: p2_layout
     p3_layout: p3_layout
     p4_layout: p4_layout
+    relative_layout: relative_layout
+
     g_amplitude: g_amplitude
     g_x_mean: g_x_mean
     g_x_sigma: g_x_sigma
@@ -1364,6 +1368,35 @@ MainWindow:
                     root: root
             
             BoxLayout:
+                id: relative_layout
+                orientation: 'horizontal'
+                size_hint_y: 0.1
+                size_hint_x: 0.9
+
+                BoxLayout:
+                    orientation: 'horizontal'
+                    size_hint_y: 1
+                    size_hint_x: 0.8
+                    padding: [dp(15), 0, 0, 0]
+
+                    Label:
+                        text: 'Is relative to start Recording position'
+                        halign: 'left'
+                        valign: 'middle'
+                        text_size: self.size
+                
+                AnchorLayout:
+                    anchor_x: 'right'
+                    anchor_y: 'center'
+                    size_hint_y: 1
+                    size_hint_x: 0.2
+
+                    RelativePositionSwitch:
+                        id: relative
+                        configKey: 'relative'
+                        root: root
+            
+            BoxLayout:
                 id: g_amplitude_layout
                 orientation: 'horizontal'
                 size_hint_y: 0.1
@@ -1479,7 +1512,7 @@ MainWindow:
                     size_hint_y: 1
                     size_hint_x: 0.2
 
-                    GaussianRelativePositionSwitch:
+                    RelativePositionSwitch:
                         id: g_relative
                         configKey: 'g_relative'
                         root: root

--- a/glowtracker/layout.kv
+++ b/glowtracker/layout.kv
@@ -120,10 +120,10 @@ MainWindow:
         height: 30
         multiline: False
         text: root.savefile
-        on_text_validate: root.path_validate()
+        on_text_validate: root.createRecordingPath()
         on_focus: app.toggle_key_binding(self.focus)
         on_focus: 
-            if not self.focus: root.path_validate()  
+            if not self.focus: root.createRecordingPath()  
                 
     MyButton:
         text: 'Save Location'

--- a/glowtracker/layout.kv
+++ b/glowtracker/layout.kv
@@ -1170,7 +1170,7 @@ MainWindow:
                 Spinner:
                     id: exteriorSpinner
                     text: 'Zero'
-                    values: 'Zero', 'Nearest', 'Constant'
+                    values: 'Zero', 'Constant'
                     on_text: root.updateExteriorChoice(); root.updateLedStageProgram()
                     size_hint_x: None
                     width: dp(100)

--- a/glowtracker/layout.kv
+++ b/glowtracker/layout.kv
@@ -1114,12 +1114,22 @@ MainWindow:
     pos: root.pos
     orientation: 'vertical'
     spacing: dp(10)
+    constanttextinput: constanttextinput
     p1x: p1x
     p1y: p1y
     p1v: p1v
+    p2x: p2x
+    p2y: p2y
+    p2v: p2v
+    p3x: p3x
+    p3y: p3y
+    p3v: p3v
+    p4x: p4x
+    p4y: p4y
+    p4v: p4v
 
-    GridLayout:
-        cols: 2
+    BoxLayout:
+        orientation: 'horizontal'
         spacing: dp(10)
 
         StackLayout:
@@ -1147,6 +1157,7 @@ MainWindow:
             BoxLayout:
                 orientation: 'horizontal'
                 size_hint_y: 0.1
+                size_hint_x: 0.9
 
                 Label:
                     text: 'Exterior'
@@ -1163,44 +1174,45 @@ MainWindow:
                     width: dp(100)
                 
                 TextInput:
+                    id: constanttextinput
                     multiline: False
                     text: ''
                     input_filter: 'float'
                     base_direction: 'rtl'
                     on_text_validate: root.updateLedStageProgram()
                     disabled: True
-                    size_hint_x: None
-                    width: dp(100)
-            
+                    size_hint_x: 1
 
             BoxLayout:
                 orientation: 'horizontal'
                 size_hint_y: 0.1
-                size_hint_x: 0.8
+                size_hint_x: 0.9
 
                 BoxLayout:
+                    id: padder
                     size_hint_x: None
                     width: dp(100)
 
                 Label:
                     text: 'x (mm)'
-                    # size_hint_x: 0.333
                 
                 Label:
                     text: 'y (mm)'
-                    # size_hint_x: 0.333
                 
                 Label:
                     text: 'z (mm)'
-                    # size_hint_x: 0.333
 
             BoxLayout:
                 orientation: 'horizontal'
                 size_hint_y: 0.1
-                size_hint_x: 0.8
+                size_hint_x: 0.9
 
                 Label:
                     text: 'Point 1'
+                    halign: 'center'
+                    valign: 'middle'
+                    size_hint_x: None
+                    text_size: [dp(100), root.height]
 
                 TextInput:
                     id: p1x
@@ -1229,10 +1241,14 @@ MainWindow:
             BoxLayout:
                 orientation: 'horizontal'
                 size_hint_y: 0.1
-                size_hint_x: 0.8
+                size_hint_x: 0.9
 
                 Label:
                     text: 'Point 2'
+                    halign: 'center'
+                    valign: 'middle'
+                    size_hint_x: None
+                    text_size: [dp(100), root.height]
 
                 TextInput:
                     id: p2x
@@ -1261,10 +1277,14 @@ MainWindow:
             BoxLayout:
                 orientation: 'horizontal'
                 size_hint_y: 0.1
-                size_hint_x: 0.8
+                size_hint_x: 0.9
 
                 Label:
                     text: 'Point 3'
+                    halign: 'center'
+                    valign: 'middle'
+                    size_hint_x: None
+                    text_size: [dp(100), root.height]
 
                 TextInput:
                     id: p3x
@@ -1293,10 +1313,14 @@ MainWindow:
             BoxLayout:
                 orientation: 'horizontal'
                 size_hint_y: 0.1
-                size_hint_x: 0.8
+                size_hint_x: 0.9
 
                 Label:
                     text: 'Point 4'
+                    halign: 'center'
+                    valign: 'middle'
+                    size_hint_x: None
+                    text_size: [dp(100), root.height]
 
                 TextInput:
                     id: p4x
@@ -1334,13 +1358,21 @@ MainWindow:
     BoxLayout:
         size_hint_y: .08
 
-        Button:
-            text: "Update"
-            size_hint_x: .2
-            on_release: root.update()
+        BoxLayout:
+            size_hint_x: .5
+
+            AnchorLayout:
+                anchor_x: 'center'
+                anchor_y: 'center'
+                
+                Button:
+                    size_hint_x: 0.5
+                    text: "Update"
+                    on_release: root.updateLedStageProgram()
+                    background_color: [94.0/255, 190.0/255, 88.0/255, 1]
         
         BoxLayout:
-            size_hint_x: .6
+            size_hint_x: .3
 
         Button:
             text: "Close"

--- a/glowtracker/layout.kv
+++ b/glowtracker/layout.kv
@@ -1534,7 +1534,7 @@ MainWindow:
     Label:
         text: 'DAQ'
         size_hint: (1,0.33)
-    OnOffButton:
+    DAQConnectionButton:
         id: daq_connection 
         border: 0,0,0,0
         size_hint_x: 0.3
@@ -1543,8 +1543,6 @@ MainWindow:
         pos_hint: {'center_x': .5, 'center_y': .5}
         background_normal: 'icons/connection_off.png'
         background_down: 'icons/connection_on.png'
-        on_state: root.connectDaq() if self.state=='down' else root.disconnectDaq()
-    
         
       
 #################################

--- a/glowtracker/layout.kv
+++ b/glowtracker/layout.kv
@@ -1088,9 +1088,11 @@ MainWindow:
     size_hint: (0.3, 1)
     cam_connection: cam_connection
     stage_connection: stage_connection
+    dac_connection: dac_connection
+    
     Label:
         text: 'Camera'
-        size_hint: (1,0.5)
+        size_hint: (1,0.33)
     OnOffButton:
         id: cam_connection
         border: 0,0,0,0
@@ -1101,9 +1103,10 @@ MainWindow:
         background_normal: 'icons/connection_off.png'
         background_down: 'icons/connection_on.png'
         on_state: root.connectCamera() if self.state=='down' else root.disconnectCamera()
+
     Label:
         text: 'Stage'
-        size_hint: (1,0.5)
+        size_hint: (1,0.33)
     OnOffButton:
         id: stage_connection 
         border: 0,0,0,0
@@ -1114,6 +1117,20 @@ MainWindow:
         background_normal: 'icons/connection_off.png'
         background_down: 'icons/connection_on.png'
         on_state: root.connectStage() if self.state=='down' else root.disconnectStage()
+
+    Label:
+        text: 'DAC'
+        size_hint: (1,0.33)
+    OnOffButton:
+        id: dac_connection 
+        border: 0,0,0,0
+        size_hint_x: 0.3
+        size_hint_y: None
+        height: self.width 
+        pos_hint: {'center_x': .5, 'center_y': .5}
+        background_normal: 'icons/connection_off.png'
+        background_down: 'icons/connection_on.png'
+        on_state: root.connectDac() if self.state=='down' else root.disconnectDac()
     
         
       

--- a/glowtracker/layout.kv
+++ b/glowtracker/layout.kv
@@ -1071,16 +1071,28 @@ MainWindow:
         BoxLayout:
             orientation: 'vertical'
             size_hint_x: None
+
+            Label:
+                text: 'Enable'
+                size_hint_y: 0.1
+                
+            LedsEnableSwitch:
+                id: ledsenableswitch
+                size_hint_y: 0.1
             
             BoxLayout:
                 # Filler
-                size_hint_y: 0.9
+                size_hint_y: 0.7
 
             Button:
                 text: "Close"
                 on_release: root.closeCallback()
                 size_hint_y: 0.1
-                
+
+
+<LedsEnableSwitch>:
+    size: root.size
+    pos: root.pos
 
 ### display if hardware is connected successfully     
 <Connections>:

--- a/glowtracker/layout.kv
+++ b/glowtracker/layout.kv
@@ -828,8 +828,8 @@ MainWindow:
         orientation: "vertical"
         FileChooserListView:
             id: filechooser
+            dirselect: False
             path: ''
-            # dirselect: True
             # path: '/home'
             on_submit: root.load(self.selection)
 

--- a/glowtracker/layout.kv
+++ b/glowtracker/layout.kv
@@ -645,6 +645,7 @@ MainWindow:
     MyButton:
         size_hint: (1, 0.1)
         text: 'LEDs'
+        on_release: root.open_leds()
     MyLabel:
         text: 'Hardware'
         size_hint: (1, 0.1)
@@ -1030,6 +1031,55 @@ MainWindow:
             size_hint_x: .15
             on_release: root.closeCallback()
 
+
+<LedsControlWidget>:
+    size: root.size
+    pos: root.pos
+    
+    orientation: 'vertical'
+
+    BoxLayout:
+        orientation: 'horizontal'
+        size_hint_y: 0.1
+
+        TextInput:
+            id: macroscriptfile
+            text: app.config.get('MacroScript', 'recentscript')
+            size_hint_x: 0.8
+        
+        Button:
+            text: "Load"
+            on_release: root.openLoadLedsControlWidget()
+            size_hint_x: None
+
+        Button:
+            text: "Save"
+            on_release: root.saveScript()
+            size_hint_x: None
+
+    BoxLayout:
+        orientation: 'horizontal'
+
+        CodeInput:
+            id: macroscripttext
+            text: ''
+            size_hint_x: 0.9
+            do_wrap: False
+            auto_indent: True
+        
+        BoxLayout:
+            orientation: 'vertical'
+            size_hint_x: None
+            
+            BoxLayout:
+                # Filler
+                size_hint_y: 0.9
+
+            Button:
+                text: "Close"
+                on_release: root.closeCallback()
+                size_hint_y: 0.1
+                
 
 ### display if hardware is connected successfully     
 <Connections>:

--- a/glowtracker/layout.kv
+++ b/glowtracker/layout.kv
@@ -765,7 +765,7 @@ MainWindow:
         orientation: 'horizontal'
 
         CodeInput:
-            id: macroscripttext
+            id: scripttext
             text: ''
             size_hint_x: 0.9
             do_wrap: False
@@ -821,7 +821,7 @@ MainWindow:
                 size_hint_y: 0.1
                 
 
-<LoadMacroScriptWidget>:
+<LoadScriptWidget>:
     BoxLayout:
         size: root.size
         pos: root.pos
@@ -843,6 +843,7 @@ MainWindow:
             Button:
                 text: "Load"
                 on_release: root.load(filechooser.selection)
+
 
 <CalibrationTabPanel>:
     size: root.size
@@ -1043,8 +1044,8 @@ MainWindow:
         size_hint_y: 0.1
 
         TextInput:
-            id: macroscriptfile
-            text: app.config.get('MacroScript', 'recentscript')
+            id: ledsscriptfile
+            text: app.config.get('LedsControl', 'recentscript')
             size_hint_x: 0.8
         
         Button:
@@ -1061,7 +1062,7 @@ MainWindow:
         orientation: 'horizontal'
 
         CodeInput:
-            id: macroscripttext
+            id: scripttext
             text: ''
             size_hint_x: 0.9
             do_wrap: False

--- a/glowtracker/layout.kv
+++ b/glowtracker/layout.kv
@@ -1033,6 +1033,25 @@ MainWindow:
             on_release: root.closeCallback()
 
 
+<LedsControlTabPanel>:
+    size: root.size
+    pos: root.pos
+    do_default_tab: False
+    tab_width: 260
+            
+    TabbedPanelItem:
+        text: 'Leds Sequencer'
+
+        LedsControlWidget:
+            id: ledssequencer
+
+    TabbedPanelItem:
+        text: 'Leds-Stage program'
+        
+        LedsStageProgramWidget:
+            id: ledsstageprogram
+
+
 <LedsControlWidget>:
     size: root.size
     pos: root.pos
@@ -1076,8 +1095,8 @@ MainWindow:
                 text: 'Enable'
                 size_hint_y: 0.1
                 
-            LedsEnableSwitch:
-                id: ledsenableswitch
+            LedsSequencerEnableSwitch:
+                id: ledssequencerenableswitch
                 size_hint_y: 0.1
             
             BoxLayout:
@@ -1090,7 +1109,69 @@ MainWindow:
                 size_hint_y: 0.1
 
 
-<LedsEnableSwitch>:
+<LedsStageProgramWidget>:
+    size: root.size
+    pos: root.pos
+    orientation: 'vertical'
+    spacing: 20
+
+    GridLayout:
+        cols: 2
+        spacing: 20
+
+        StackLayout:
+            orientation: 'tb-lr'
+            size_hint_x: 0.6
+
+            BoxLayout:
+                orientation: 'horizontal'
+                # size_hint_y: 0.1
+
+                Label:
+                    text: 'Enable'
+                
+                LedsStageProgramEnableSwitch:
+                    id: ledsstageprogramenableswitch
+            
+            Label:
+                text: 'Some Text'
+            
+            Label:
+                text: 'Some More Text'
+
+
+        BoxLayout:
+            orientation: 'vertical'
+            size_hint_x: 0.4
+            Label:
+                text: 'Visualization'
+                size_hint_y: 0.1
+            Image:
+                id: visualizationplot
+    
+    BoxLayout:
+        size_hint_y: .08
+
+        Button:
+            text: "Update"
+            size_hint_x: .2
+            on_release: root.update()
+        
+        BoxLayout:
+            size_hint_x: .6
+
+        Button:
+            text: "Close"
+            size_hint_x: .2
+            on_release: root.closeCallback()
+
+
+<LedsSequencerEnableSwitch>:
+    size: root.size
+    pos: root.pos
+
+
+<LedsStageProgramEnableSwitch>:
     size: root.size
     pos: root.pos
 

--- a/glowtracker/layout.kv
+++ b/glowtracker/layout.kv
@@ -1167,11 +1167,13 @@ MainWindow:
     g_x_sigma: g_x_sigma
     g_y_mean: g_y_mean
     g_y_sigma: g_y_sigma
+    g_relative: g_relative
     g_amplitude_layout: g_amplitude_layout
     g_x_mean_layout: g_x_mean_layout
     g_x_sigma_layout: g_x_sigma_layout
     g_y_mean_layout: g_y_mean_layout
     g_y_sigma_layout: g_y_sigma_layout
+    g_relative_layout: g_relative_layout
 
     BoxLayout:
         orientation: 'horizontal'
@@ -1453,6 +1455,34 @@ MainWindow:
                     configKey: 'g_y_sigma'
                     root: root
             
+            BoxLayout:
+                id: g_relative_layout
+                orientation: 'horizontal'
+                size_hint_y: 0.1
+                size_hint_x: 0.9
+
+                BoxLayout:
+                    orientation: 'horizontal'
+                    size_hint_y: 1
+                    size_hint_x: 0.8
+                    padding: [dp(15), 0, 0, 0]
+
+                    Label:
+                        text: 'Is relative to start Recording position'
+                        halign: 'left'
+                        valign: 'middle'
+                        text_size: self.size
+                
+                AnchorLayout:
+                    anchor_x: 'right'
+                    anchor_y: 'center'
+                    size_hint_y: 1
+                    size_hint_x: 0.2
+
+                    GaussianRelativePositionSwitch:
+                        id: g_relative
+                        configKey: 'g_relative'
+                        root: root
             
         BoxLayout:
             orientation: 'vertical'

--- a/glowtracker/layout.kv
+++ b/glowtracker/layout.kv
@@ -1114,7 +1114,7 @@ MainWindow:
     pos: root.pos
     orientation: 'vertical'
     spacing: dp(10)
-    exterior: exterior
+    exteriorSpinner: exteriorSpinner
     constanttextinput: constanttextinput
     p1x: p1x
     p1y: p1y
@@ -1168,16 +1168,16 @@ MainWindow:
                     text_size: [dp(100), root.height]
                 
                 Spinner:
-                    id: exterior
+                    id: exteriorSpinner
                     text: 'Zero'
                     values: 'Zero', 'Nearest', 'Constant'
-                    on_kv_post: root.updateExteriorChoice()
-                    on_text: root.updateExteriorChoice()
+                    on_text: root.updateExteriorChoice(); root.updateLedStageProgram()
                     size_hint_x: None
                     width: dp(100)
                 
                 LedsStageTextInput:
                     id: constanttextinput
+                    on_kv_post: root.updateExteriorChoice()
                     on_text_validate: root.updateLedStageProgram()
                     configKey: 'constanttextinput'
 

--- a/glowtracker/layout.kv
+++ b/glowtracker/layout.kv
@@ -1202,8 +1202,8 @@ MainWindow:
                 
                 Spinner:
                     id: modeSpinner
-                    text: 'FourPoint'
-                    values: 'FourPoint', 'Gaussian'
+                    text: 'Gaussian'
+                    values: 'Gaussian', 'FourPoint'
                     on_text: root.updateMode(); root.updateLedStageProgram()
                     size_hint_x: None
                     width: dp(100)

--- a/glowtracker/layout.kv
+++ b/glowtracker/layout.kv
@@ -1037,7 +1037,7 @@ MainWindow:
     size: root.size
     pos: root.pos
     do_default_tab: False
-    tab_width: 260
+    tab_width: 220
             
     TabbedPanelItem:
         text: 'Leds Sequencer'
@@ -1113,36 +1113,218 @@ MainWindow:
     size: root.size
     pos: root.pos
     orientation: 'vertical'
-    spacing: 20
+    spacing: dp(10)
+    p1x: p1x
+    p1y: p1y
+    p1v: p1v
 
     GridLayout:
         cols: 2
-        spacing: 20
+        spacing: dp(10)
 
         StackLayout:
             orientation: 'tb-lr'
-            size_hint_x: 0.6
-
+            size_hint_x: 0.5
+            spacing: [0, dp(5)]
+            
             BoxLayout:
                 orientation: 'horizontal'
-                # size_hint_y: 0.1
+                size_hint_y: 0.1
 
                 Label:
                     text: 'Enable'
+                    halign: 'center'
+                    valign: 'middle'
+                    size_hint_x: None
+                    text_size: [dp(100), root.height]
                 
                 LedsStageProgramEnableSwitch:
+                    size_hint_x: None
+                    width: dp(100)
                     id: ledsstageprogramenableswitch
             
-            Label:
-                text: 'Some Text'
+
+            BoxLayout:
+                orientation: 'horizontal'
+                size_hint_y: 0.1
+
+                Label:
+                    text: 'Exterior'
+                    halign: 'center'
+                    valign: 'middle'
+                    size_hint_x: None
+                    text_size: [dp(100), root.height]
+                
+                Spinner:
+                    text: 'Zero'
+                    values: 'Zero', 'Nearest', 'Constant'
+                    on_text: print("The Exterior value spinner {} has text {}".format(self, self.text))
+                    size_hint_x: None
+                    width: dp(100)
+                
+                TextInput:
+                    multiline: False
+                    text: ''
+                    input_filter: 'float'
+                    base_direction: 'rtl'
+                    on_text_validate: root.updateLedStageProgram()
+                    disabled: True
+                    size_hint_x: None
+                    width: dp(100)
             
-            Label:
-                text: 'Some More Text'
 
+            BoxLayout:
+                orientation: 'horizontal'
+                size_hint_y: 0.1
+                size_hint_x: 0.8
 
+                BoxLayout:
+                    size_hint_x: None
+                    width: dp(100)
+
+                Label:
+                    text: 'x (mm)'
+                    # size_hint_x: 0.333
+                
+                Label:
+                    text: 'y (mm)'
+                    # size_hint_x: 0.333
+                
+                Label:
+                    text: 'z (mm)'
+                    # size_hint_x: 0.333
+
+            BoxLayout:
+                orientation: 'horizontal'
+                size_hint_y: 0.1
+                size_hint_x: 0.8
+
+                Label:
+                    text: 'Point 1'
+
+                TextInput:
+                    id: p1x
+                    multiline: False
+                    text: ''
+                    input_filter: 'float'
+                    base_direction: 'rtl'
+                    on_text_validate: root.updateLedStageProgram()
+                
+                TextInput:
+                    id: p1y
+                    multiline: False
+                    text: ''
+                    input_filter: 'float'
+                    base_direction: 'rtl'
+                    on_text_validate: root.updateLedStageProgram()
+                
+                TextInput:
+                    id: p1v
+                    multiline: False
+                    text: ''
+                    input_filter: 'float'
+                    base_direction: 'rtl'
+                    on_text_validate: root.updateLedStageProgram()
+
+            BoxLayout:
+                orientation: 'horizontal'
+                size_hint_y: 0.1
+                size_hint_x: 0.8
+
+                Label:
+                    text: 'Point 2'
+
+                TextInput:
+                    id: p2x
+                    multiline: False
+                    text: ''
+                    input_filter: 'float'
+                    base_direction: 'rtl'
+                    on_text_validate: root.updateLedStageProgram()
+                
+                TextInput:
+                    id: p2y
+                    multiline: False
+                    text: ''
+                    input_filter: 'float'
+                    base_direction: 'rtl'
+                    on_text_validate: root.updateLedStageProgram()
+                
+                TextInput:
+                    id: p2v
+                    multiline: False
+                    text: ''
+                    input_filter: 'float'
+                    base_direction: 'rtl'
+                    on_text_validate: root.updateLedStageProgram()
+            
+            BoxLayout:
+                orientation: 'horizontal'
+                size_hint_y: 0.1
+                size_hint_x: 0.8
+
+                Label:
+                    text: 'Point 3'
+
+                TextInput:
+                    id: p3x
+                    multiline: False
+                    text: ''
+                    input_filter: 'float'
+                    base_direction: 'rtl'
+                    on_text_validate: root.updateLedStageProgram()
+                
+                TextInput:
+                    id: p3y
+                    multiline: False
+                    text: ''
+                    input_filter: 'float'
+                    base_direction: 'rtl'
+                    on_text_validate: root.updateLedStageProgram()
+                
+                TextInput:
+                    id: p3v
+                    multiline: False
+                    text: ''
+                    input_filter: 'float'
+                    base_direction: 'rtl'
+                    on_text_validate: root.updateLedStageProgram()
+
+            BoxLayout:
+                orientation: 'horizontal'
+                size_hint_y: 0.1
+                size_hint_x: 0.8
+
+                Label:
+                    text: 'Point 4'
+
+                TextInput:
+                    id: p4x
+                    multiline: False
+                    text: ''
+                    input_filter: 'float'
+                    base_direction: 'rtl'
+                    on_text_validate: root.updateLedStageProgram()
+                
+                TextInput:
+                    id: p4y
+                    multiline: False
+                    text: ''
+                    input_filter: 'float'
+                    base_direction: 'rtl'
+                    on_text_validate: root.updateLedStageProgram()
+                
+                TextInput:
+                    id: p4v
+                    multiline: False
+                    text: ''
+                    input_filter: 'float'
+                    base_direction: 'rtl'
+                    on_text_validate: root.updateLedStageProgram()
+            
         BoxLayout:
             orientation: 'vertical'
-            size_hint_x: 0.4
+            size_hint_x: 0.5
             Label:
                 text: 'Visualization'
                 size_hint_y: 0.1

--- a/glowtracker/settings/gui_settings.json
+++ b/glowtracker/settings/gui_settings.json
@@ -420,11 +420,12 @@
         "title": "LedsControl"
     },
     {
-        "type": "bool",
-        "title": "Enable LED Sequencer",
-        "desc": "Enable the LED sequencer during recording.",
+        "type": "options",
+        "title": "Mode",
+        "desc": "Modes of controlling LED",
         "section": "LedsControl",
-        "key": "isenablesequencer"
+        "key": "mode",
+        "options": ["Off", "Sequencer", "StageProgram"]
     },
     {
         "type": "path",
@@ -434,11 +435,12 @@
         "key": "ledsequencescript"
     },
     {
-        "type": "bool",
-        "title": "Enable LED-Stage program",
-        "desc": "Enable the LED-Stage program during recording",
+        "type": "options",
+        "title": "StageProgramMode",
+        "desc": "Modes of controlling LED as Stage-Program",
         "section": "LedsControl",
-        "key": "isenablestageprogram"
+        "key": "stageprogrammode",
+        "options": ["FourPoint", "Gaussian"]
     },
     {
         "type": "title",

--- a/glowtracker/settings/gui_settings.json
+++ b/glowtracker/settings/gui_settings.json
@@ -444,6 +444,13 @@
     },
     {
         "type": "bool",
+        "title": "FourPoint Relative Position",
+        "desc": "Is the bottom-left corner of the FourPoint relative to the start-Recording position",
+        "section": "LedsControl",
+        "key": "relative"
+    },
+    {
+        "type": "bool",
         "title": "Gaussian Relative Position",
         "desc": "Are the gaussian means relative to the start-Recording position",
         "section": "LedsControl",

--- a/glowtracker/settings/gui_settings.json
+++ b/glowtracker/settings/gui_settings.json
@@ -421,10 +421,24 @@
     },
     {
         "type": "bool",
-        "title": "Enable",
-        "desc": "Enable the LED control sequence.",
+        "title": "Enable LED Sequencer",
+        "desc": "Enable the LED sequencer during recording.",
         "section": "LedsControl",
-        "key": "isenable"
+        "key": "isenablesequencer"
+    },
+    {
+        "type": "path",
+        "title": "LED sequence file",
+        "desc": "The file path of LED sequence",
+        "section": "LedsControl",
+        "key": "ledsequencescript"
+    },
+    {
+        "type": "bool",
+        "title": "Enable LED-Stage program",
+        "desc": "Enable the LED-Stage program during recording",
+        "section": "LedsControl",
+        "key": "isenablestageprogram"
     },
     {
         "type": "title",

--- a/glowtracker/settings/gui_settings.json
+++ b/glowtracker/settings/gui_settings.json
@@ -443,6 +443,13 @@
         "options": ["FourPoint", "Gaussian"]
     },
     {
+        "type": "bool",
+        "title": "Gaussian Relative Position",
+        "desc": "Are the gaussian means relative to the start-Recording position",
+        "section": "LedsControl",
+        "key": "g_relative"
+    },
+    {
         "type": "title",
         "title": "Developer"
     },

--- a/glowtracker/settings/gui_settings.json
+++ b/glowtracker/settings/gui_settings.json
@@ -417,6 +417,17 @@
     },
     {
         "type": "title",
+        "title": "LedsControl"
+    },
+    {
+        "type": "bool",
+        "title": "Enable",
+        "desc": "Enable the LED control sequence.",
+        "section": "LedsControl",
+        "key": "isenable"
+    },
+    {
+        "type": "title",
         "title": "Developer"
     },
     {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
     "zaber-motion",
     "overrides",
     "pandas",
-    "pypylon",
+    "pypylon>=26.1.0",
     "itk-elastix",
     "platformdirs",
     "pyparsing",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ maintainers = [
 ]
 readme = "README.md"
 license-files = ["LICENSE.txt"]
-requires-python = ">=3.11"
+requires-python = ">=3.10"
 dependencies = [
     "kivy>=2.2.0",
     "matplotlib",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,8 @@ dependencies = [
     "pypylon",
     "itk-elastix",
     "platformdirs",
-    "pyparsing"
+    "pyparsing",
+    "labjackpython"
 ]
 classifiers = [
     "Intended Audience :: Science/Research",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ maintainers = [
 ]
 readme = "README.md"
 license-files = ["LICENSE.txt"]
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 dependencies = [
     "kivy>=2.2.0",
     "matplotlib",


### PR DESCRIPTION
# Main feature
Added a set of features to control DAQ (LabJack U3) synchronously at the start of recording. There are two modes of control: Sequencer, and StageProgram.

There are also many bug fixes and improvements, listed under the Major and Minor section.

## Sequencer
Specify DAQ output voltage as a function of frame number or timestamp.
Below are example scripts showing syntax.
Begin first line with either `mode: [frame]` or `mode: [time]`.
Each following line starts with a number of frame, follow by a colon, and a command of either `[on, {voltage}]` or `[off]`.
It is chronologically flexible but it would be mentally better to write in a chronological order.

### Frame
```
mode: [frame]
10: [on, 1.5]
20: [off]
200: [on, 1]
220: [on, 3.2]
400: [off]
```
### Time
```
mode: [time]
5.0: [on, 2]
10: [off]
20: [on, 5]
70: [off]
```

## StageProgram
Specify DAQ output voltage as a function of stage position.
There are two stage program modes: `Gaussian` and `FourPoint`.

- `Gaussian` is a normallized 2D Gaussian function
$$\text{vol}=A \cdot\exp{\left(-\frac{(x - \mu_x)^2}{2 \sigma_x^2}-\frac{(y - \mu_y)^2}{2 \sigma_y^2}\right)},$$
where $A$ is an amplitude (peak of the distribution).

- `FourPoint` is bilinear interpolation between four 2D vertices $\left[p_1, p_2, p_3, p_4 \right]$, each with its weight $\left[w_1, w_2, w_3, w_4 \right]$. 
Points outside quadrilateral can be set to $0$ or a constant float value.

For both of the stage program modes, there is a toggle switch to interpret the parameters as relative to the starting position of the recording.

# Minor updates and bug fixes
- Update recording path creation to be more robust. Handle cases where recording path doesn't exist at the beginning of recording.
- Fixed resuming LiveView from Continuous recording doesn't fully terminate the recording thread.
- Fixed stopping-recording to show the correct number of recorded frames. Also prevented double calling to stopImageAcquisition.
- Properly reset LiveAnalysisData after disabled.
- Fixed updating image-stage matrix from on_config_change caused invalid result.
- Set open file dialogue starting location to the current file path if not empty
- Added commands to close unwanted plot figure window that were generated when creating visualization plot.
- Show tracking dialogue only once after app start.

# Dependencies
- Added `labjackpython`.
- Increased `pypylon>=26.1.0` to support for newer version of camera .pfs file.
